### PR TITLE
Phase 1 UI Fixes & Phase 2 Audio Control Center Consolidation

### DIFF
--- a/src/app/audio-control/page.tsx
+++ b/src/app/audio-control/page.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState } from 'react'
+import { ArrowLeft, Music, Speaker, Volume2, Disc, Sliders, Settings, Brain } from 'lucide-react'
+import Link from 'next/link'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import SportsBarLayout from '@/components/SportsBarLayout'
+import SportsBarHeader from '@/components/SportsBarHeader'
+import AtlasProgrammingInterface from '@/components/AtlasProgrammingInterface'
+import AtlasAIMonitor from '@/components/AtlasAIMonitor'
+import AudioProcessorManager from '@/components/AudioProcessorManager'
+import AudioZoneControl from '@/components/AudioZoneControl'
+import SoundtrackControl from '@/components/SoundtrackControl'
+import SoundtrackConfiguration from '@/components/SoundtrackConfiguration'
+
+export default function AudioControlCenterPage() {
+  const headerActions = (
+    <Link href="/" className="btn-secondary">
+      <span>← Back to Home</span>
+    </Link>
+  )
+
+  return (
+    <SportsBarLayout>
+      <SportsBarHeader
+        title="Audio Control Center"
+        subtitle="Complete audio system management - Atlas, Zones, and Soundtrack"
+        icon={<Music className="w-8 h-8 text-teal-400" />}
+        actions={headerActions}
+      />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card p-6">
+          <Tabs defaultValue="zones" className="w-full">
+            <TabsList className="grid w-full grid-cols-4 bg-slate-800/50">
+              <TabsTrigger 
+                value="zones" 
+                className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
+              >
+                <Sliders className="w-4 h-4" />
+                <span>Zone Control</span>
+              </TabsTrigger>
+              <TabsTrigger 
+                value="atlas" 
+                className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
+              >
+                <Volume2 className="w-4 h-4" />
+                <span>Atlas System</span>
+              </TabsTrigger>
+              <TabsTrigger 
+                value="soundtrack" 
+                className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
+              >
+                <Disc className="w-4 h-4" />
+                <span>Soundtrack</span>
+              </TabsTrigger>
+              <TabsTrigger 
+                value="processors" 
+                className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
+              >
+                <Settings className="w-4 h-4" />
+                <span>Processors</span>
+              </TabsTrigger>
+            </TabsList>
+
+            {/* Zone Control Tab */}
+            <TabsContent value="zones" className="mt-6">
+              <div className="space-y-6">
+                <div className="flex items-center space-x-3 mb-4">
+                  <Sliders className="w-6 h-6 text-cyan-400" />
+                  <div>
+                    <h2 className="text-2xl font-bold text-slate-100">Audio Zone Control</h2>
+                    <p className="text-slate-300 text-sm">Manage volume and settings for all audio zones</p>
+                  </div>
+                </div>
+                <AudioZoneControl />
+              </div>
+            </TabsContent>
+
+            {/* Atlas System Tab */}
+            <TabsContent value="atlas" className="mt-6">
+              <div className="space-y-6">
+                <div className="flex items-center space-x-3 mb-4">
+                  <Volume2 className="w-6 h-6 text-teal-400" />
+                  <div>
+                    <h2 className="text-2xl font-bold text-slate-100">Atlas Audio System</h2>
+                    <p className="text-slate-300 text-sm">AI-Powered Audio Processing & Zone Management</p>
+                  </div>
+                </div>
+                
+                <Tabs defaultValue="configuration" className="w-full">
+                  <TabsList className="grid w-full grid-cols-2 bg-slate-800/30">
+                    <TabsTrigger 
+                      value="configuration" 
+                      className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
+                    >
+                      <Settings className="w-4 h-4" />
+                      <span>Configuration</span>
+                    </TabsTrigger>
+                    <TabsTrigger 
+                      value="ai-monitor" 
+                      className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
+                    >
+                      <Brain className="w-4 h-4" />
+                      <span>AI Monitor</span>
+                    </TabsTrigger>
+                  </TabsList>
+                  
+                  <TabsContent value="configuration" className="mt-6">
+                    <AtlasProgrammingInterface />
+                  </TabsContent>
+                  
+                  <TabsContent value="ai-monitor" className="mt-6">
+                    <AtlasAIMonitor 
+                      processorId="atlas-001"
+                      processorModel="AZM8"
+                      autoRefresh={true}
+                      refreshInterval={30000}
+                    />
+                  </TabsContent>
+                </Tabs>
+              </div>
+            </TabsContent>
+
+            {/* Soundtrack Tab */}
+            <TabsContent value="soundtrack" className="mt-6">
+              <div className="space-y-6">
+                <div className="flex items-center space-x-3 mb-4">
+                  <Disc className="w-6 h-6 text-purple-400" />
+                  <div>
+                    <h2 className="text-2xl font-bold text-slate-100">Soundtrack Your Brand</h2>
+                    <p className="text-slate-300 text-sm">Configure music streaming and zone-specific playback</p>
+                  </div>
+                </div>
+                
+                <div className="space-y-6">
+                  {/* Main Configuration */}
+                  <SoundtrackConfiguration />
+                  
+                  {/* Zone-Specific Controls */}
+                  <div className="card p-6">
+                    <h3 className="text-lg font-semibold text-slate-100 mb-4">Zone-Specific Soundtrack Control</h3>
+                    <div className="space-y-4">
+                      <SoundtrackControl zoneName="Main Audio System" />
+                      
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+                        <SoundtrackControl zoneId="mainbar" zoneName="Main Bar" compact />
+                        <SoundtrackControl zoneId="pavilion" zoneName="Pavilion" compact />
+                        <SoundtrackControl zoneId="partyroom" zoneName="Party Room" compact />
+                        <SoundtrackControl zoneId="upstairs" zoneName="Upstairs" compact />
+                        <SoundtrackControl zoneId="patio" zoneName="Patio" compact />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </TabsContent>
+
+            {/* Processors Tab */}
+            <TabsContent value="processors" className="mt-6">
+              <div className="space-y-6">
+                <div className="flex items-center space-x-3 mb-4">
+                  <Settings className="w-6 h-6 text-blue-400" />
+                  <div>
+                    <h2 className="text-2xl font-bold text-slate-100">Audio Processor Management</h2>
+                    <p className="text-slate-300 text-sm">Configure and monitor Atlas IED audio processors</p>
+                  </div>
+                </div>
+                <AudioProcessorManager />
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </main>
+    </SportsBarLayout>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@
 import { useState } from 'react'
 import StreamingPlatformsWidget from '@/components/StreamingPlatformsWidget'
 import LayoutConfiguration from '@/components/LayoutConfiguration'
-import { Settings } from 'lucide-react'
+import { Settings, Music } from 'lucide-react'
 
 export default function Home() {
   const [showLayoutConfig, setShowLayoutConfig] = useState(false)
@@ -88,27 +88,14 @@ export default function Home() {
                 <h3 className="text-lg font-semibold text-slate-200 mb-4">🎵 Music & Audio</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   <a 
-                    href="/soundtrack"
-                    className="block p-6 bg-sportsBar-700/80 rounded-xl border border-purple-400/30 hover:bg-sportsBar-600/80 hover:border-purple-400/50 transition-all duration-200"
+                    href="/audio-control"
+                    className="block p-6 bg-gradient-to-br from-teal-600/40 to-purple-600/40 rounded-xl border-2 border-teal-400/50 hover:border-teal-400/70 hover:from-teal-600/50 hover:to-purple-600/50 transition-all duration-200 shadow-lg col-span-1 md:col-span-2 lg:col-span-3"
                   >
-                    <h3 className="font-semibold text-purple-300 mb-2">🎵 Soundtrack Your Brand</h3>
-                    <p className="text-purple-200/80 text-sm">Professional music streaming control</p>
-                  </a>
-                  
-                  <a 
-                    href="/atlas-config"
-                    className="block p-6 bg-sportsBar-700/80 rounded-xl border border-teal-400/30 hover:bg-sportsBar-600/80 hover:border-teal-400/50 transition-all duration-200"
-                  >
-                    <h3 className="font-semibold text-teal-300 mb-2">🔊 Audio Zones</h3>
-                    <p className="text-teal-200/80 text-sm">Zone control & volume management</p>
-                  </a>
-                  
-                  <a 
-                    href="/audio-manager"
-                    className="block p-6 bg-sportsBar-700/80 rounded-xl border border-cyan-400/30 hover:bg-sportsBar-600/80 hover:border-cyan-400/50 transition-all duration-200"
-                  >
-                    <h3 className="font-semibold text-cyan-300 mb-2">🎛️ Audio Processor</h3>
-                    <p className="text-cyan-200/80 text-sm">Atlas IED processor configuration</p>
+                    <div className="flex items-center space-x-3 mb-2">
+                      <Music className="w-6 h-6 text-teal-300" />
+                      <h3 className="font-bold text-teal-200 text-xl">🎵 Audio Control Center</h3>
+                    </div>
+                    <p className="text-teal-100/90 text-sm">Complete audio system management - Atlas zones, processors, and Soundtrack streaming in one place</p>
                   </a>
                 </div>
               </div>
@@ -149,14 +136,6 @@ export default function Home() {
                   >
                     <h4 className="font-medium text-yellow-300 mb-1">⚡ CEC TV Control</h4>
                     <p className="text-yellow-200/80 text-sm">HDMI-CEC TV power & input</p>
-                  </a>
-                  
-                  <a 
-                    href="/atlas-config"
-                    className="block p-4 bg-sportsBar-700/60 rounded-lg border border-teal-400/30 hover:bg-sportsBar-600/80 hover:border-teal-400/50 transition-all duration-200"
-                  >
-                    <h4 className="font-medium text-teal-300 mb-1">🔊 Atlas Audio</h4>
-                    <p className="text-teal-200/80 text-sm">Audio system configuration</p>
                   </a>
                   
                   <a 

--- a/src/components/ApiKeysManager.tsx
+++ b/src/components/ApiKeysManager.tsx
@@ -182,7 +182,7 @@ export default function ApiKeysManager() {
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                 placeholder="e.g., My Grok API Key"
-                className="w-full border border-slate-700 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full bg-slate-800/50 border border-slate-700 rounded-md px-3 py-2 text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 required
               />
             </div>
@@ -194,12 +194,12 @@ export default function ApiKeysManager() {
               <select
                 value={formData.provider}
                 onChange={(e) => setFormData({ ...formData, provider: e.target.value })}
-                className="w-full border border-slate-700 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full bg-slate-800/50 border border-slate-700 rounded-md px-3 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 required
               >
-                <option value="">Select a provider</option>
+                <option value="" className="bg-slate-800 text-slate-100">Select a provider</option>
                 {PROVIDERS.map((provider) => (
-                  <option key={provider.value} value={provider.value}>
+                  <option key={provider.value} value={provider.value} className="bg-slate-800 text-slate-100">
                     {provider.label}
                   </option>
                 ))}
@@ -220,7 +220,7 @@ export default function ApiKeysManager() {
                 value={formData.keyValue}
                 onChange={(e) => setFormData({ ...formData, keyValue: e.target.value })}
                 placeholder={editingKey ? "Leave empty to keep current key" : "Enter your API key"}
-                className="w-full border border-slate-700 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full bg-slate-800/50 border border-slate-700 rounded-md px-3 py-2 text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 required={!editingKey}
               />
             </div>
@@ -234,7 +234,7 @@ export default function ApiKeysManager() {
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 placeholder="Optional description for this API key"
                 rows={2}
-                className="w-full border border-slate-700 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full bg-slate-800/50 border border-slate-700 rounded-md px-3 py-2 text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>
 

--- a/src/components/DeviceAIAssistant.tsx
+++ b/src/components/DeviceAIAssistant.tsx
@@ -157,22 +157,22 @@ export default function DeviceAIAssistant() {
           <select
             value={selectedDevice}
             onChange={(e) => setSelectedDevice(e.target.value)}
-            className="px-3 py-2 border rounded-md"
+            className="px-3 py-2 bg-slate-800/50 border border-slate-700 rounded-md text-slate-100"
           >
-            <option value="all">All Devices</option>
-            <option value="directv">DirecTV Only</option>
-            <option value="firetv">Fire TV Only</option>
-            <option value="ir">IR Devices Only</option>
+            <option value="all" className="bg-slate-800 text-slate-100">All Devices</option>
+            <option value="directv" className="bg-slate-800 text-slate-100">DirecTV Only</option>
+            <option value="firetv" className="bg-slate-800 text-slate-100">Fire TV Only</option>
+            <option value="ir" className="bg-slate-800 text-slate-100">IR Devices Only</option>
           </select>
           
           <select
             value={timeframe}
             onChange={(e) => setTimeframe(e.target.value)}
-            className="px-3 py-2 border rounded-md"
+            className="px-3 py-2 bg-slate-800/50 border border-slate-700 rounded-md text-slate-100"
           >
-            <option value="1h">Last Hour</option>
-            <option value="24h">Last 24 Hours</option>
-            <option value="7d">Last 7 Days</option>
+            <option value="1h" className="bg-slate-800 text-slate-100">Last Hour</option>
+            <option value="24h" className="bg-slate-800 text-slate-100">Last 24 Hours</option>
+            <option value="7d" className="bg-slate-800 text-slate-100">Last 7 Days</option>
           </select>
           
           <Button onClick={fetchDeviceAIAnalysis} className="flex items-center gap-2">

--- a/src/components/IntelligentTroubleshooter.tsx
+++ b/src/components/IntelligentTroubleshooter.tsx
@@ -192,12 +192,12 @@ export default function IntelligentTroubleshooter() {
           <select
             value={selectedDevice}
             onChange={(e) => setSelectedDevice(e.target.value)}
-            className="px-3 py-2 border rounded-md"
+            className="px-3 py-2 bg-slate-800/50 border border-slate-700 rounded-md text-slate-100"
           >
-            <option value="all">All Devices</option>
-            <option value="directv">DirecTV Only</option>
-            <option value="firetv">Fire TV Only</option>
-            <option value="ir">IR Devices Only</option>
+            <option value="all" className="bg-slate-800 text-slate-100">All Devices</option>
+            <option value="directv" className="bg-slate-800 text-slate-100">DirecTV Only</option>
+            <option value="firetv" className="bg-slate-800 text-slate-100">Fire TV Only</option>
+            <option value="ir" className="bg-slate-800 text-slate-100">IR Devices Only</option>
           </select>
           
           <Button


### PR DESCRIPTION
## Overview
This PR addresses Phase 1 UI readability issues and implements Phase 2 consolidations by creating a unified Audio Control Center.

## Phase 1 - UI Readability Fixes ✅

### Issues Fixed
- **White/unreadable inputs and dropdowns** in AI Hub components
- Missing background colors causing white-on-white text
- Poor contrast in form elements

### Components Updated
1. **ApiKeysManager.tsx**
   - Fixed all input fields with `bg-slate-800/50 text-slate-100 placeholder-slate-400`
   - Fixed select dropdowns with proper dark backgrounds
   - Added dark styling to all option elements

2. **DeviceAIAssistant.tsx**
   - Fixed device and timeframe select dropdowns
   - Applied consistent dark theme styling

3. **IntelligentTroubleshooter.tsx**
   - Fixed device selection dropdown
   - Ensured proper text contrast

### Styling Applied
```css
bg-slate-800/50          /* Dark semi-transparent background */
text-slate-100           /* Light text for readability */
placeholder-slate-400    /* Visible placeholder text */
border-slate-700         /* Subtle borders */
```

## Phase 2 - Audio Control Center Consolidation ✅

### New Unified Page
Created `/audio-control` that consolidates three separate pages:

#### Consolidated Pages
1. **Atlas Config** (`/atlas-config`) → Now "Atlas System" tab
2. **Audio Manager** (`/audio-manager`) → Now "Zone Control" and "Processors" tabs
3. **Soundtrack** (`/soundtrack`) → Now "Soundtrack" tab

### Features
- **4 Main Tabs:**
  1. **Zone Control** - Audio zone management and volume control
  2. **Atlas System** - Atlas IED configuration with AI Monitor sub-tabs
  3. **Soundtrack** - Music streaming with zone-specific controls
  4. **Processors** - Audio processor management

- **Preserved Functionality:**
  - All existing components imported and working
  - Zone-specific soundtrack controls maintained
  - Atlas AI monitoring preserved
  - Audio processor management intact

### Navigation Updates
- **Main Dashboard:**
  - Replaced 3 separate audio links with single "Audio Control Center"
  - Added prominent gradient card spanning full width
  - Removed duplicate "Atlas Audio" link from Configuration section

## Color Scheme Consistency ✅

### Applied Throughout
- Dark theme with proper contrast ratios
- Consistent use of slate-800/700 backgrounds
- Light text (slate-100/200/300) for readability
- Proper focus states and transitions
- Accessible color combinations

### CSS Classes Used
- `bg-slate-800/50` - Semi-transparent dark backgrounds
- `text-slate-100` - Primary text color
- `text-slate-300` - Secondary text color
- `border-slate-700` - Subtle borders
- `placeholder-slate-400` - Visible placeholders

## Testing Checklist
- [x] All inputs and dropdowns are readable
- [x] Proper text contrast throughout
- [x] Navigation updated correctly
- [x] All audio functionality preserved
- [x] Consistent dark theme applied
- [x] No broken links or references

## Files Changed
- `src/app/audio-control/page.tsx` - New consolidated audio page
- `src/app/page.tsx` - Updated navigation
- `src/components/ApiKeysManager.tsx` - Fixed input styling
- `src/components/DeviceAIAssistant.tsx` - Fixed dropdown styling
- `src/components/IntelligentTroubleshooter.tsx` - Fixed dropdown styling

## Deployment Notes
- Old audio pages (`/atlas-config`, `/audio-manager`, `/soundtrack`) still exist for backward compatibility
- Can be removed in a future PR after confirming everything works
- Update script will work correctly - just pull and restart

## Screenshots
The Audio Control Center now provides a unified interface with proper dark theme styling and readable text throughout all form elements.

---

**Ready for Review** ✅
All Phase 1 issues fixed and Phase 2 consolidation complete with consistent dark theme styling.