### PR TITLE
Remove redundant Processors tab from Audio Control Center

### DIFF
--- a/src/app/audio-control/page.tsx
+++ b/src/app/audio-control/page.tsx
@@ -32,7 +32,7 @@ export default function AudioControlCenterPage() {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="card p-6">
           <Tabs defaultValue="zones" className="w-full">
-            <TabsList className="grid w-full grid-cols-4 bg-slate-800/50">
+            <TabsList className="grid w-full grid-cols-3 bg-slate-800/50">
               <TabsTrigger 
                 value="zones" 
                 className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
@@ -53,13 +53,6 @@ export default function AudioControlCenterPage() {
               >
                 <Disc className="w-4 h-4" />
                 <span>Soundtrack</span>
-              </TabsTrigger>
-              <TabsTrigger 
-                value="processors" 
-                className="flex items-center space-x-2 data-[state=active]:bg-slate-700 data-[state=active]:text-slate-100"
-              >
-                <Settings className="w-4 h-4" />
-                <span>Processors</span>
               </TabsTrigger>
             </TabsList>
 
@@ -153,20 +146,6 @@ export default function AudioControlCenterPage() {
                     </div>
                   </div>
                 </div>
-              </div>
-            </TabsContent>
-
-            {/* Processors Tab */}
-            <TabsContent value="processors" className="mt-6">
-              <div className="space-y-6">
-                <div className="flex items-center space-x-3 mb-4">
-                  <Settings className="w-6 h-6 text-blue-400" />
-                  <div>
-                    <h2 className="text-2xl font-bold text-slate-100">Audio Processor Management</h2>
-                    <p className="text-slate-300 text-sm">Configure and monitor Atlas IED audio processors</p>
-                  </div>
-                </div>
-                <AudioProcessorManager />
               </div>
             </TabsContent>
           </Tabs>


### PR DESCRIPTION
## Summary
This PR removes the redundant "Processors" tab from the Audio Control Center, consolidating all Atlas IED processor management functionality under the "Atlas System" tab.

## Problem
The Audio Control Center had 4 tabs, with tabs 2 and 4 both managing Atlas IED audio processors:
- Tab 2: "Atlas System" - Atlas IED processor management
- Tab 4: "Processors" - Atlas IED processor management (duplicate)

## Solution
- ✅ Removed the redundant "Processors" tab
- ✅ Consolidated to 3 tabs: Zone Control, Atlas System, Soundtrack
- ✅ Updated tab grid layout from 4 columns to 3 columns
- ✅ All processor management functionality remains accessible through "Atlas System" tab
- ✅ Maintained all existing features and components

## Changes
- Modified `src/app/audio-control/page.tsx`:
  - Changed TabsList grid from `grid-cols-4` to `grid-cols-3`
  - Removed "Processors" TabsTrigger
  - Removed "Processors" TabsContent section
  - All Atlas IED processor functionality preserved in "Atlas System" tab

## Testing
- Verify Audio Control Center displays 3 tabs instead of 4
- Confirm Atlas System tab contains all processor management features
- Ensure Zone Control and Soundtrack tabs remain unchanged
- Check responsive layout with 3-column grid

## Impact
- Cleaner, more intuitive UI
- Eliminates user confusion from duplicate tabs
- No functionality loss - all features remain accessible
- Update script compatibility maintained