### PR TITLE
Fix TypeScript build error in BartenderRemoteControl

### DIFF
--- a/src/components/BartenderRemoteControl.tsx
+++ b/src/components/BartenderRemoteControl.tsx
@@ -1429,7 +1429,9 @@ export default function BartenderRemoteControl() {
                 </div>
                 
                 <WolfpackInputSelector
-                  onSelect={(inputNumber) => {
+                  isOpen={showMatrixSelector}
+                  matrixNumber={currentMatrixNumber}
+                  onSelectInput={(inputNumber, inputLabel) => {
                     // Route the selected input to the matrix output
                     routeMatrixInput(currentMatrixNumber, inputNumber, selectedAudioZone)
                     setShowMatrixSelector(false)


### PR DESCRIPTION
## Problem
TypeScript build was failing with error at line 1432:
```
Type error: Type '{ onSelect: (inputNumber: any) => void; onClose: () => void; }' is not assignable to type 'IntrinsicAttributes & WolfpackInputSelectorProps'.
Property 'onSelect' does not exist on type 'IntrinsicAttributes & WolfpackInputSelectorProps'.
```

## Root Cause
The `WolfpackInputSelector` component was being called with incorrect prop names that didn't match its TypeScript interface.

## Solution
Updated the component usage in `BartenderRemoteControl.tsx` to use the correct props:
- ✅ Changed `onSelect` → `onSelectInput` (correct prop name)
- ✅ Added missing `isOpen={showMatrixSelector}` prop
- ✅ Added missing `matrixNumber={currentMatrixNumber}` prop
- ✅ Updated callback signature to accept both `inputNumber` and `inputLabel` parameters

## Verification
- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ All required props now provided
- ✅ Prop types match component interface

## Impact
- Fixes critical build error blocking deployment
- No functional changes to application behavior
- Type-safe component usage