### PR TITLE
feat: Make AudioZoneControl fully dynamic with Atlas API data

### DIFF
--- a/src/app/api/audio-processor/inputs/route.ts
+++ b/src/app/api/audio-processor/inputs/route.ts
@@ -1,0 +1,96 @@
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { getAvailableInputs } from '@/lib/atlas-models-config'
+
+/**
+ * GET /api/audio-processor/inputs
+ * Fetch available inputs for an Atlas audio processor
+ * 
+ * Query params:
+ * - processorId: The ID of the audio processor
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const processorId = searchParams.get('processorId')
+
+    if (!processorId) {
+      return NextResponse.json(
+        { error: 'Processor ID is required' },
+        { status: 400 }
+      )
+    }
+
+    // Fetch the processor to get its model
+    const processor = await prisma.audioProcessor.findUnique({
+      where: { id: processorId }
+    })
+
+    if (!processor) {
+      return NextResponse.json(
+        { error: 'Audio processor not found' },
+        { status: 404 }
+      )
+    }
+
+    // Get available inputs from the model configuration
+    const inputs = getAvailableInputs(processor.model)
+
+    // Fetch any custom input configurations from Atlas config
+    try {
+      const configResponse = await fetch(
+        `${request.nextUrl.origin}/api/atlas/configuration?processorId=${processorId}`
+      )
+      const configData = await configResponse.json()
+
+      if (configData.success && configData.inputs && configData.inputs.length > 0) {
+        // Merge custom configurations with model defaults
+        const customInputs = configData.inputs.map((customInput: any) => {
+          const modelInput = inputs.find(i => i.id === customInput.id || i.number === customInput.physicalInput)
+          return {
+            ...modelInput,
+            ...customInput,
+            isCustom: true
+          }
+        })
+
+        return NextResponse.json({
+          success: true,
+          inputs: customInputs,
+          processorId,
+          model: processor.model
+        })
+      }
+    } catch (configError) {
+      console.log('No custom input configuration found, using model defaults')
+    }
+
+    // Return model default inputs
+    return NextResponse.json({
+      success: true,
+      inputs: inputs.map(input => ({
+        id: input.id,
+        number: input.number,
+        name: input.name,
+        type: input.type,
+        connector: input.connector,
+        description: input.description,
+        priority: input.priority,
+        isCustom: false
+      })),
+      processorId,
+      model: processor.model
+    })
+
+  } catch (error) {
+    console.error('Error fetching audio processor inputs:', error)
+    return NextResponse.json(
+      { 
+        error: 'Failed to fetch inputs',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/audio-processor/outputs/route.ts
+++ b/src/app/api/audio-processor/outputs/route.ts
@@ -1,0 +1,136 @@
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { getAvailableOutputs } from '@/lib/atlas-models-config'
+
+/**
+ * GET /api/audio-processor/outputs
+ * Fetch available outputs/zones for an Atlas audio processor
+ * 
+ * Query params:
+ * - processorId: The ID of the audio processor
+ * - includeGroups: Whether to detect and include zone groups (default: true)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const processorId = searchParams.get('processorId')
+    const includeGroups = searchParams.get('includeGroups') !== 'false'
+
+    if (!processorId) {
+      return NextResponse.json(
+        { error: 'Processor ID is required' },
+        { status: 400 }
+      )
+    }
+
+    // Fetch the processor to get its model
+    const processor = await prisma.audioProcessor.findUnique({
+      where: { id: processorId }
+    })
+
+    if (!processor) {
+      return NextResponse.json(
+        { error: 'Audio processor not found' },
+        { status: 404 }
+      )
+    }
+
+    // Get available outputs from the model configuration
+    const modelOutputs = getAvailableOutputs(processor.model)
+
+    // Fetch any custom output configurations from Atlas config
+    let outputs = modelOutputs.map(output => ({
+      id: output.id,
+      number: output.number,
+      name: output.name,
+      type: output.type,
+      connector: output.connector,
+      powerRating: output.powerRating,
+      description: output.description,
+      isCustom: false,
+      levelDb: -20, // Default level
+      muted: false,
+      groupId: null as string | null
+    }))
+
+    try {
+      const configResponse = await fetch(
+        `${request.nextUrl.origin}/api/atlas/configuration?processorId=${processorId}`
+      )
+      const configData = await configResponse.json()
+
+      if (configData.success && configData.outputs && configData.outputs.length > 0) {
+        // Merge custom configurations with model defaults
+        outputs = configData.outputs.map((customOutput: any) => {
+          const modelOutput = modelOutputs.find(
+            o => o.id === customOutput.id || o.number === customOutput.physicalOutput
+          )
+          return {
+            ...modelOutput,
+            id: customOutput.id || modelOutput?.id,
+            number: customOutput.physicalOutput || modelOutput?.number,
+            name: customOutput.name || modelOutput?.name,
+            type: customOutput.type || modelOutput?.type,
+            levelDb: customOutput.levelDb ?? -20,
+            muted: customOutput.muted ?? false,
+            groupId: customOutput.groupId || null,
+            isCustom: true
+          }
+        })
+      }
+    } catch (configError) {
+      console.log('No custom output configuration found, using model defaults')
+    }
+
+    // Detect zone groups if requested
+    let groups: any[] = []
+    if (includeGroups) {
+      const groupMap = new Map<string, any[]>()
+      
+      outputs.forEach(output => {
+        if (output.groupId) {
+          if (!groupMap.has(output.groupId)) {
+            groupMap.set(output.groupId, [])
+          }
+          groupMap.get(output.groupId)!.push(output)
+        }
+      })
+
+      // Create group objects
+      groups = Array.from(groupMap.entries()).map(([groupId, groupOutputs]) => ({
+        id: groupId,
+        name: `Zone Group: ${groupOutputs.map(o => o.name).join(', ')}`,
+        outputIds: groupOutputs.map(o => o.id),
+        outputs: groupOutputs,
+        levelDb: groupOutputs[0]?.levelDb ?? -20,
+        muted: groupOutputs.every(o => o.muted)
+      }))
+
+      // Filter out grouped outputs from individual outputs list
+      const groupedOutputIds = new Set(
+        groups.flatMap(g => g.outputIds)
+      )
+      outputs = outputs.filter(o => !groupedOutputIds.has(o.id))
+    }
+
+    return NextResponse.json({
+      success: true,
+      outputs,
+      groups,
+      processorId,
+      model: processor.model,
+      hasGroups: groups.length > 0
+    })
+
+  } catch (error) {
+    console.error('Error fetching audio processor outputs:', error)
+    return NextResponse.json(
+      { 
+        error: 'Failed to fetch outputs',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
This PR makes the AudioZoneControl component fully dynamic by pulling inputs and outputs from Atlas API endpoints instead of using hardcoded values. Zone groups are automatically detected and displayed.

## Changes Made

### New API Endpoints
1. **`/api/audio-processor/inputs`** - Dynamically fetches available inputs
   - Pulls from Atlas model configuration based on processor model
   - Merges with custom configurations from Atlas config file
   - Filters out internal matrix audio buses from UI
   - Returns input metadata (type, connector, description)

2. **`/api/audio-processor/outputs`** - Dynamically fetches outputs/zones
   - Pulls from Atlas model configuration
   - Merges with custom configurations
   - **Automatic zone group detection** based on `groupId` field
   - Returns individual zones and grouped zones separately

### Updated AudioZoneControl Component
- **Dynamic Inputs**: Fetches inputs from API instead of hardcoded list
- **Dynamic Outputs**: Fetches zones from API with group detection
- **Zone Groups**: Groups displayed with purple badge and Users icon
- **Matrix Functionality Preserved**: Matrix 1-4 inputs still route video sources
- **Enhanced UI**: Groups shown before individual zones
- **Error Handling**: Proper fallbacks if API fails
- **Loading States**: Shows spinner while fetching data

## Zone Group Detection
- Zones with the same `groupId` are automatically grouped
- Groups control all member zones simultaneously
- Groups displayed with distinct purple styling
- Individual zones shown separately if not in a group

## Matrix Functionality
✅ **Matrix 1-4 inputs preserved** - Still trigger Wolfpack video routing
✅ **Audio/Video routing intact** - Matrix inputs route both audio and video
✅ **Atlas inputs separate** - Direct audio routing for Atlas physical inputs

## Testing
- ✅ TypeScript compilation passes
- ✅ Build succeeds without errors
- ✅ Fallback configuration works if API fails
- ✅ Zone groups detected and displayed correctly
- ✅ Matrix inputs still functional

## Requirements Met
- [x] Inputs pulled from Atlas API (not hardcoded)
- [x] Outputs/zones pulled from Atlas API
- [x] Zone groups detected and used when applicable
- [x] Matrix 1-4 functionality preserved
- [x] Build passes
- [x] Proper error handling and fallbacks

## API Structure
```typescript
// GET /api/audio-processor/inputs?processorId=atlas-001
{
  success: true,
  inputs: [
    { id, number, name, type, connector, description, priority, isCustom }
  ],
  processorId: "atlas-001",
  model: "AZM8"
}

// GET /api/audio-processor/outputs?processorId=atlas-001&includeGroups=true
{
  success: true,
  outputs: [ /* individual zones */ ],
  groups: [
    { id, name, outputIds, outputs, levelDb, muted }
  ],
  processorId: "atlas-001",
  model: "AZM8",
  hasGroups: true
}
```

## Screenshots
Zone groups are displayed with purple badges and the Users icon to distinguish them from individual zones.

## Notes
- The component maintains backward compatibility with existing configurations
- If no Atlas configuration exists, it falls back to default zones
- Matrix inputs are always shown first for easy access to video routing
- Atlas physical inputs (balanced, RCA, Dante) shown after Matrix inputs
- Internal matrix audio buses are hidden from the UI (they're for internal routing)

---

**Ready for review and testing!** 🎉