### PR TITLE
Fix: Correct ScheduledTask type import from node-cron

### DIFF
--- a/src/services/presetCronService.ts
+++ b/src/services/presetCronService.ts
@@ -1,8 +1,8 @@
 
-import cron from 'node-cron'
+import cron, { ScheduledTask } from 'node-cron'
 import { reorderAllPresets } from './presetReorderService'
 
-let cronJob: cron.ScheduledTask | null = null
+let cronJob: ScheduledTask | null = null
 
 /**
  * Initialize the monthly preset reordering cron job


### PR DESCRIPTION
## Problem
TypeScript build was failing with error:
```
Type error: Cannot find namespace 'cron'.
  5 | let cronJob: cron.ScheduledTask | null = null
```

## Solution
- Import `ScheduledTask` type directly from `node-cron` package
- Changed `cron.ScheduledTask` to `ScheduledTask` on line 5

## Changes
- Updated import statement: `import cron, { ScheduledTask } from 'node-cron'`
- Fixed type annotation: `let cronJob: ScheduledTask | null = null`

## Testing
This fix resolves the TypeScript compilation error. The build should now pass successfully.

## Related
Fixes the build failure blocking deployment of the preset quick access feature.