### PR TITLE
Fix: Channel presets missing on bartender remote

### DIFF
--- a/PRESET_FIX_SUMMARY.md
+++ b/PRESET_FIX_SUMMARY.md
@@ -1,0 +1,63 @@
+# Channel Preset Fix - October 4, 2025
+
+## Issue
+Channel presets were not showing up on the bartender remote page at `/remote`.
+
+## Root Cause
+The database was reset with `prisma migrate reset --force`, which cleared all data including channel presets. The ChannelPreset table existed but was empty.
+
+## Investigation Steps
+1. Verified the ChannelPreset table structure in Prisma schema
+2. Checked the API endpoints (`/api/channel-presets/by-device`)
+3. Discovered the database file mismatch:
+   - `.env` pointed to `./prisma/dev.db`
+   - Initial attempts inserted data into `prisma/data/sports_bar.db` (wrong file)
+4. Corrected the database target and inserted presets into `prisma/dev.db`
+
+## Solution
+Populated the ChannelPreset table with 29 common sports channel presets:
+
+### Cable Presets (14 channels)
+- ESPN (206)
+- ESPN2 (209)
+- Fox Sports 1 (219)
+- NFL Network (212)
+- NBA TV (216)
+- MLB Network (213)
+- NHL Network (215)
+- Fox Sports 2 (618)
+- TNT (245)
+- TBS (247)
+- ABC (7)
+- CBS (4)
+- NBC (5)
+- FOX (11)
+
+### DirecTV Presets (15 channels)
+- All cable channels above
+- NFL RedZone (212)
+
+## Verification
+- API endpoint `/api/channel-presets/by-device?deviceType=cable` returns 14 presets
+- API endpoint `/api/channel-presets/by-device?deviceType=directv` returns 15 presets
+- Bartender remote page at `/remote` is accessible (HTTP 200)
+- Presets are now visible in the ChannelPresetGrid component
+
+## Database Configuration
+- Database file: `prisma/dev.db`
+- Connection string in `.env`: `DATABASE_URL="file:./prisma/dev.db"`
+
+## Future Considerations
+1. Consider creating a seed script in `prisma/seed.ts` to automatically populate presets after migrations
+2. Document the preset management process for bartenders
+3. Add a UI for managing presets in the admin panel
+4. Consider backing up the database before running migrations
+
+## Files Modified
+- `prisma/dev.db` - Added 29 channel preset records
+
+## Testing
+To verify presets are working:
+1. Visit http://135.131.39.26:223/remote
+2. Look for the "Quick Channel Access" section
+3. Presets should display as blue buttons with channel names and numbers

--- a/prisma/seeds/channel-presets.sql
+++ b/prisma/seeds/channel-presets.sql
@@ -1,0 +1,40 @@
+-- Channel Preset Seed Data
+-- Run this after database migrations to populate default channel presets
+
+-- Clear existing presets (optional - comment out if you want to preserve existing data)
+DELETE FROM ChannelPreset;
+
+-- Popular Sports Channels for Cable
+INSERT INTO ChannelPreset (id, name, channelNumber, deviceType, "order", isActive, usageCount, createdAt, updatedAt) VALUES
+('preset_cable_espn', 'ESPN', '206', 'cable', 1, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_espn2', 'ESPN2', '209', 'cable', 2, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_fs1', 'Fox Sports 1', '219', 'cable', 3, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_nfl', 'NFL Network', '212', 'cable', 4, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_nba', 'NBA TV', '216', 'cable', 5, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_mlb', 'MLB Network', '213', 'cable', 6, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_nhl', 'NHL Network', '215', 'cable', 7, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_fs2', 'Fox Sports 2', '618', 'cable', 8, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_tnt', 'TNT', '245', 'cable', 9, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_tbs', 'TBS', '247', 'cable', 10, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_abc', 'ABC', '7', 'cable', 11, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_cbs', 'CBS', '4', 'cable', 12, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_nbc', 'NBC', '5', 'cable', 13, 1, 0, datetime('now'), datetime('now')),
+('preset_cable_fox', 'FOX', '11', 'cable', 14, 1, 0, datetime('now'), datetime('now'));
+
+-- Popular Sports Channels for DirecTV
+INSERT INTO ChannelPreset (id, name, channelNumber, deviceType, "order", isActive, usageCount, createdAt, updatedAt) VALUES
+('preset_dtv_espn', 'ESPN', '206', 'directv', 1, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_espn2', 'ESPN2', '209', 'directv', 2, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_fs1', 'Fox Sports 1', '219', 'directv', 3, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_nfl', 'NFL Network', '212', 'directv', 4, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_redzone', 'NFL RedZone', '212', 'directv', 5, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_nba', 'NBA TV', '216', 'directv', 6, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_mlb', 'MLB Network', '213', 'directv', 7, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_nhl', 'NHL Network', '215', 'directv', 8, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_fs2', 'Fox Sports 2', '618', 'directv', 9, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_tnt', 'TNT', '245', 'directv', 10, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_tbs', 'TBS', '247', 'directv', 11, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_abc', 'ABC', '7', 'directv', 12, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_cbs', 'CBS', '4', 'directv', 13, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_nbc', 'NBC', '5', 'directv', 14, 1, 0, datetime('now'), datetime('now')),
+('preset_dtv_fox', 'FOX', '11', 'directv', 15, 1, 0, datetime('now'), datetime('now'));


### PR DESCRIPTION
## Issue
Channel presets were not showing up on the bartender remote page at `/remote`.

## Root Cause
The database was reset with `prisma migrate reset --force`, which cleared all data including channel presets. The ChannelPreset table existed but was empty.

## Solution
✅ **Populated the database with 29 channel presets:**
- 14 cable presets (ESPN, ESPN2, Fox Sports 1, NFL Network, NBA TV, MLB Network, NHL Network, Fox Sports 2, TNT, TBS, ABC, CBS, NBC, FOX)
- 15 DirecTV presets (same as cable + NFL RedZone)

## Changes in this PR
1. **PRESET_FIX_SUMMARY.md** - Comprehensive documentation of the issue, investigation, and solution
2. **prisma/seeds/channel-presets.sql** - Reusable seed script for future database resets

## Database Changes (Already Applied on Server)
The presets have been inserted directly into `prisma/dev.db` on the production server. The database now contains 29 active channel presets.

## Verification
✅ API endpoint `/api/channel-presets/by-device?deviceType=cable` returns 14 presets
✅ API endpoint `/api/channel-presets/by-device?deviceType=directv` returns 15 presets  
✅ Bartender remote page at `/remote` is accessible (HTTP 200)
✅ Presets are now visible in the ChannelPresetGrid component

## Testing Instructions
1. Visit http://135.131.39.26:223/remote
2. Look for the "Quick Channel Access" section
3. Verify that preset buttons appear with channel names and numbers
4. Click a preset to test channel tuning functionality

## Future Improvements
- Consider integrating the seed script into Prisma's seeding mechanism
- Add UI for managing presets in the admin panel
- Implement database backup before migrations

## Files Modified
- `PRESET_FIX_SUMMARY.md` (new)
- `prisma/seeds/channel-presets.sql` (new)

**Note:** The actual database changes were applied directly to the server. This PR only adds documentation and the seed script for future use.