### PR TITLE
Fix recommendations array type in AI status route

### DIFF
--- a/src/app/api/ai-system/status/route.ts
+++ b/src/app/api/ai-system/status/route.ts
@@ -58,7 +58,7 @@ export async function GET(request: NextRequest) {
         reason: 'AI system not available or test failed'
       },
       systemInfo,
-      recommendations: []
+      recommendations: [] as string[]
     }
 
     // Add recommendations based on status


### PR DESCRIPTION
## Description
Fixed TypeScript error where the `recommendations` array was inferred as `never[]` instead of `string[]`.

## Changes
- Added explicit type annotation `as string[]` to the recommendations array initialization in the AI status route

## Issue
The response object's recommendations property was initialized as an empty array `[]`, which TypeScript inferred as `never[]`. This prevented pushing string values to the array, causing a build error.

## Solution
Explicitly typed the array as `string[]` using type assertion: `recommendations: [] as string[]`

This allows the subsequent `.push()` calls to work correctly with string values.