### PR TITLE
Fix TypeScript type mismatch errors

### DIFF
--- a/src/app/api/firetv-devices/guide-data/route.ts
+++ b/src/app/api/firetv-devices/guide-data/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest) {
     const end = endTime ? new Date(endTime).toISOString() : new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
 
     let guideData: any[] = []
-    let deviceInfo = null
+    let deviceInfo: { model: string; androidVersion: string; fireOSVersion: string; serialNumber: string; } | null | undefined = null
 
     try {
       // Connect to Fire TV via ADB


### PR DESCRIPTION
## Summary
Fixed TypeScript type mismatch error in `firetv-devices/guide-data/route.ts`.

## Changes
- Updated `deviceInfo` variable declaration to properly handle the union type `{ model: string; androidVersion: string; fireOSVersion: string; serialNumber: string; } | null | undefined`
- Previously initialized as `null` but was being assigned a value that could be `object | undefined`, causing TypeScript error

## Testing
- ✅ Build completed successfully with no TypeScript errors
- ✅ All type checks passed

## Error Fixed
```
Type error: Type '{ model: string; androidVersion: string; fireOSVersion: string; serialNumber: string; } | undefined' is not assignable to type 'null'.
  Type 'undefined' is not assignable to type 'null'.
```

This was the only instance of this specific type mismatch pattern in the codebase.