### PR TITLE
Fix TypeScript type errors in IR devices routes

### DIFF
--- a/src/app/api/ir-devices/model-codes/route.ts
+++ b/src/app/api/ir-devices/model-codes/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
     // Get specific IR code for a function
     const codes = await globalCacheAPI.getModelCodes(modelId)
     
-    let irCode = null
+    let irCode: string | null = null
     for (const codeset of codes) {
       const func = codeset.functions?.find(f => f.name === functionName)
       if (func) {


### PR DESCRIPTION
## Summary
Fixed TypeScript type error in `src/app/api/ir-devices/model-codes/route.ts` where `irCode` variable was typed as `null` but assigned a `string` value.

## Changes
- Changed `let irCode = null` to `let irCode: string | null = null` on line 56

## Verification
- ✅ `npx tsc --noEmit` passes with no TypeScript errors
- ⚠️ Note: `npm run build` encounters a SIGBUS error (infrastructure issue, not related to this code change)

## Issue
This fixes the TypeScript error:
```
Type error: Type 'string' is not assignable to type 'null'.
> 60 |         irCode = func.code
```