### PR TITLE
Fix Promise.allSettled type guard errors

### DIFF
--- a/src/components/EnhancedBartenderRemoteControl.tsx
+++ b/src/components/EnhancedBartenderRemoteControl.tsx
@@ -233,7 +233,7 @@ export default function EnhancedBartenderRemoteControl() {
         logError(
           new Error(`${failures.length} device operations failed`), 
           'input_change_partial_failure',
-          { failures: failures.map(f => f.reason) }
+          { failures: failures.map(f => f.status === 'rejected' ? f.reason : 'Unknown error') }
         )
       }
 


### PR DESCRIPTION
## Summary
Fixed TypeScript type guard error when accessing `reason` property on `Promise.allSettled` results.

## Changes
- Added type guard check `f.status === 'rejected'` before accessing `f.reason` in `EnhancedBartenderRemoteControl.tsx` line 236
- This ensures we only access the `reason` property on `PromiseRejectedResult` types, not on the union type `PromiseSettledResult`

## Error Fixed
```
Type error: Property 'reason' does not exist on type 'PromiseSettledResult<any>'.
  Property 'reason' does not exist on type 'PromiseFulfilledResult<any>'.
```

## Verification
- Searched entire codebase for similar patterns - all other `Promise.allSettled` usages already have proper type guards
- TypeScript compilation passes with no errors
- Full build attempted (encountered system memory constraints, but TypeScript validation succeeded)

## Files Changed
- `src/components/EnhancedBartenderRemoteControl.tsx`