### PR TITLE
Fix: Resolve 404 root route issue by rebuilding application

### DIFF
--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -1,0 +1,25 @@
+# Fix Summary
+
+## Issue
+The root route (/) was returning 404 errors because the .next build directory was stale and didn't include the root page in the route manifest.
+
+## Root Cause
+- The app/page.tsx file existed and was correctly configured
+- However, the .next/app-path-routes-manifest.json did not contain an entry for '/page'
+- This caused Next.js to serve the 404 page for all root route requests
+
+## Solution
+1. Removed the stale .next build directory
+2. Rebuilt the application using 'npm run build'
+3. Verified the root route now exists in the manifest
+4. Tested the server - all routes now return 200 OK
+
+## Files Changed
+- Deleted .next/ directory (build cache)
+- No source code changes were needed
+
+## Verification
+- curl -I http://localhost:3000/ returns HTTP/1.1 200 OK
+- Server is running successfully on port 3000
+- All other routes (/ai-hub, /remote, etc.) also working correctly
+


### PR DESCRIPTION
## Problem
The Sports Bar TV Controller application was returning **404 errors** for the root route (`/`) even though `app/page.tsx` existed and was correctly configured.

## Root Cause Analysis
The issue was caused by a **stale build cache**:
- The `.next/app-path-routes-manifest.json` file did not contain an entry for the root page (`"/page": "/"`)
- This caused Next.js to serve the 404 page for all requests to the root route
- The PM2 logs showed: `GET / 404` repeatedly

## Solution
1. ✅ Stopped all conflicting processes on port 3000
2. ✅ Removed the stale `.next` build directory
3. ✅ Rebuilt the application using `npm run build`
4. ✅ Verified the root route now exists in the build manifest
5. ✅ Tested the server - all routes return 200 OK

## Verification
```bash
# Root route now works
curl -I http://localhost:3000/
# HTTP/1.1 200 OK ✅

# Other routes also working
curl -I http://localhost:3000/ai-hub
# HTTP/1.1 200 OK ✅

curl -I http://localhost:3000/remote
# HTTP/1.1 200 OK ✅
```

## Files Changed
- Added `FIX_SUMMARY.md` documenting the issue and resolution
- No source code changes were needed (the code was already correct)

## Impact
- ✅ Root route now loads correctly
- ✅ No more 404 errors
- ✅ Server running successfully on port 3000
- ✅ All application routes functional

## Note
This was purely a build cache issue. The application code was correct, but the build artifacts were out of sync. A clean rebuild resolved the problem completely.