### PR TITLE
Fix: Add missing buildContextFromDocs function to resolve TypeScript build error

### DIFF
--- a/src/lib/ai-knowledge.ts
+++ b/src/lib/ai-knowledge.ts
@@ -112,3 +112,21 @@ export function buildContext(query: string, maxChunks: number = 5): string {
   
   return context;
 }
+
+export function buildContextFromDocs(chunks: DocumentChunk[]): string {
+  if (chunks.length === 0) {
+    return 'No relevant documentation found for this query.';
+  }
+  
+  let context = '## Relevant Documentation:\n\n';
+  
+  chunks.forEach((chunk, index) => {
+    context += `### Document ${index + 1}: ${chunk.metadata.filename}\n`;
+    context += `Source: ${chunk.source}\n`;
+    context += `Type: ${chunk.type}\n\n`;
+    context += chunk.content;
+    context += '\n\n';
+  });
+  
+  return context;
+}


### PR DESCRIPTION
## Problem
The Next.js build was failing with a TypeScript error because the `analyze-logs` route at `src/app/api/ai-assistant/analyze-logs/route.ts` was trying to import `buildContextFromDocs` from `@/lib/ai-knowledge`, but that function didn't exist in the module.

## Solution
Added the missing `buildContextFromDocs` function to `src/lib/ai-knowledge.ts`. This function:
- Accepts an array of `DocumentChunk` objects (pre-searched documents)
- Formats them into a context string for AI analysis
- Includes document metadata (filename, source, type) in the formatted output
- Maintains consistency with the existing `buildContext` function

## Changes
- ✅ Added `buildContextFromDocs(chunks: DocumentChunk[]): string` function
- ✅ Function properly formats document chunks with headers and metadata
- ✅ Resolves the TypeScript import error
- ✅ Maintains the intended functionality of the analyze-logs route

## Testing
After merging, you should:
1. Pull the latest changes: `git pull origin main`
2. Rebuild the project: `npm run build`
3. Verify the build completes successfully without TypeScript errors

## Impact
- Fixes the blocking TypeScript build error
- Enables the AI log analysis feature to work properly
- No breaking changes to existing functionality