### PR TITLE
Fix TypeScript error: Use correct DocumentChunk properties in analyze-logs route

### DIFF
--- a/src/app/api/ai-assistant/analyze-logs/route.ts
+++ b/src/app/api/ai-assistant/analyze-logs/route.ts
@@ -111,8 +111,8 @@ export async function POST(request: NextRequest) {
         context += buildContextFromDocs(relevantDocs);
         sources = relevantDocs.map(doc => ({
           source: doc.source,
-          title: doc.title,
-          section: doc.section
+          title: doc.metadata.filename,
+          type: doc.type
         }));
       }
     }


### PR DESCRIPTION
## Problem
The build was failing with a TypeScript error in `src/app/api/ai-assistant/analyze-logs/route.ts` at lines 114-115. The code was trying to access `title` and `section` properties on `DocumentChunk` objects, but these properties don't exist in the `DocumentChunk` interface definition.

## Solution
Updated the analyze-logs route to use the correct properties that are actually available on `DocumentChunk`:
- Changed `doc.title` → `doc.metadata.filename` (provides the document name)
- Changed `doc.section` → `doc.type` (provides document type: 'pdf', 'markdown', or 'code')

## Changes
- **File**: `src/app/api/ai-assistant/analyze-logs/route.ts`
- **Lines**: 114-115
- **Impact**: Fixes TypeScript compilation error while maintaining the intended functionality of providing source information for AI analysis

## Testing
This fix aligns the code with the `DocumentChunk` interface defined in `src/lib/ai-knowledge.ts` (lines 5-16). The build should now complete successfully.

## Next Steps
After merging:
1. Pull the latest changes: `git pull origin main`
2. Rebuild the project: `npm run build`
3. Verify the build completes without TypeScript errors