### PR TITLE
Fix: Export DocumentChunk interface for TypeScript compatibility

### DIFF
--- a/src/lib/ai-knowledge.ts
+++ b/src/lib/ai-knowledge.ts
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 
-interface DocumentChunk {
+export interface DocumentChunk {
   id: string;
   content: string;
   source: string;


### PR DESCRIPTION
## Problem
The build was failing with a TypeScript error:
```
Module './ai-knowledge' declares 'DocumentChunk' locally, but it is not exported.
```

This occurred because `ai-knowledge-enhanced.ts` was trying to import `DocumentChunk` from `ai-knowledge.ts`, but the interface wasn't exported.

## Solution
Added the `export` keyword to the `DocumentChunk` interface definition in `src/lib/ai-knowledge.ts`.

## Changes
- ✅ Exported `DocumentChunk` interface (line 5)
- ✅ No other interfaces need to be exported (KnowledgeBase is internal only)

## Testing
After merging this PR:
1. Pull the latest changes: `git pull origin main`
2. Rebuild the project: `npm run build`
3. The TypeScript error should be resolved

## Impact
- Allows other modules to import and use the `DocumentChunk` type
- Fixes build failures related to this type import
- No breaking changes - purely additive export