### PR TITLE
Fix TypeScript error: Replace kb.documents with kb.chunks

### DIFF
--- a/src/lib/ai-knowledge-enhanced.ts
+++ b/src/lib/ai-knowledge-enhanced.ts
@@ -103,10 +103,10 @@ export async function buildEnhancedContext(
       const queryLower = query.toLowerCase();
       const queryTerms = queryLower.split(/\s+/).filter(term => term.length > 2);
       
-      const scoredDocs = kb.documents.map(doc => {
+      const scoredDocs = kb.chunks.map(doc => {
         let score = 0;
         const contentLower = doc.content.toLowerCase();
-        const titleLower = (doc.title || '').toLowerCase();
+        const titleLower = (doc.metadata.filename || '').toLowerCase();
         
         for (const term of queryTerms) {
           if (titleLower.includes(term)) score += 5;
@@ -127,7 +127,7 @@ export async function buildEnhancedContext(
       if (relevantDocs.length > 0) {
         context += '\n\n=== DOCUMENTATION CONTEXT ===\n\n';
         relevantDocs.forEach((doc, index) => {
-          context += `[Document ${index + 1}: ${doc.title || doc.source}]\n`;
+          context += `[Document ${index + 1}: ${doc.metadata.filename || doc.source}]\n`;
           context += doc.content.substring(0, 2000); // Limit doc length
           context += '\n\n---\n\n';
         });


### PR DESCRIPTION
## Problem
The build was failing with a TypeScript error in `ai-knowledge-enhanced.ts` at line 106:
```
Property 'documents' does not exist on type 'KnowledgeBase'
```

## Solution
Fixed the property access to match the actual `KnowledgeBase` interface structure defined in `ai-knowledge.ts`:

- Changed `kb.documents` to `kb.chunks` (line 106)
- Updated `doc.title` to `doc.metadata.filename` (lines 109 and 130)

## Changes
- `src/lib/ai-knowledge-enhanced.ts`: Updated property access to use correct KnowledgeBase interface properties

## Testing
This fix aligns the code with the actual interface definition and should resolve the TypeScript compilation error.

## Related
Fixes the build failure preventing deployment.