### PR TITLE
Fix TypeScript return type error in loadKnowledgeBase

### DIFF
--- a/src/lib/ai-knowledge.ts
+++ b/src/lib/ai-knowledge.ts
@@ -50,6 +50,10 @@ export function loadKnowledgeBase(): KnowledgeBase {
   cachedKnowledgeBase = JSON.parse(data);
   cacheTimestamp = now;
   
+  if (!cachedKnowledgeBase) {
+    throw new Error('Failed to parse knowledge base');
+  }
+  
   return cachedKnowledgeBase;
 }
 


### PR DESCRIPTION
## Problem
The build was failing with a TypeScript error in `ai-knowledge.ts` at line 53:
```
Type 'KnowledgeBase | null' is not assignable to type 'KnowledgeBase'
```

The `loadKnowledgeBase()` function was trying to return `cachedKnowledgeBase` which has type `KnowledgeBase | null`, but the function's return type was declared as `KnowledgeBase` (non-nullable).

## Solution
Added an explicit null check after `JSON.parse()` to ensure `cachedKnowledgeBase` is not null before returning it. If the parse somehow results in null, the function now throws a descriptive error.

## Changes
- Added null check with error throw in `loadKnowledgeBase()` function
- This satisfies TypeScript's type checker while maintaining the same runtime behavior
- No changes needed to callers since the function still returns `KnowledgeBase` type

## Testing
- Verified TypeScript compilation passes for `ai-knowledge.ts`
- No breaking changes to existing code