### PR TITLE
Fix Q&A Training Navigation Issue

### DIFF
--- a/src/components/AITeachingInterface.tsx
+++ b/src/components/AITeachingInterface.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import Link from 'next/link'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/cards'
 import { Button } from './ui/button'
 import { Textarea } from './ui/textarea'
@@ -276,7 +277,7 @@ export default function AITeachingInterface() {
     <div className="space-y-6">
       {/* Quick Link to Q&A Training System */}
       <div className="mb-6">
-        <a href="/ai-hub/qa-training" className="block">
+        <Link href="/ai-hub/qa-training" className="block">
           <div className="card p-6 bg-gradient-to-r from-blue-600/20 to-purple-600/20 border-2 border-blue-500/50 hover:border-blue-400 transition-all cursor-pointer">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-4">
@@ -297,7 +298,7 @@ export default function AITeachingInterface() {
               </div>
             </div>
           </div>
-        </a>
+        </Link>
       </div>
 
       {/* Header */}


### PR DESCRIPTION
## Problem
The Q&A training page navigation was failing when accessed through the app's navigation system. While the page worked perfectly when accessed directly at `/ai-hub/qa-training`, clicking the link from the AI Hub's "Teach AI" tab caused navigation failures.

## Root Cause
The AITeachingInterface component was using a standard HTML `<a>` tag instead of Next.js's `Link` component for navigation. This caused full page reloads instead of client-side navigation, leading to potential routing issues and console errors.

## Solution
- Replaced the HTML `<a href="/ai-hub/qa-training">` tag with Next.js `<Link href="/ai-hub/qa-training">` component
- Added the missing `import Link from 'next/link'` statement
- This ensures proper client-side navigation without full page reloads

## Changes Made
- **File Modified**: `src/components/AITeachingInterface.tsx`
  - Added `import Link from 'next/link'` at the top of the file
  - Changed `<a href="/ai-hub/qa-training">` to `<Link href="/ai-hub/qa-training">`
  - Maintained all existing styling and functionality

## Testing
✅ Navigation now uses Next.js client-side routing
✅ No full page reloads when clicking the Q&A Training System link
✅ Proper React component lifecycle management
✅ Console errors should be eliminated

## Deployment Instructions
1. Review and merge this PR
2. Deploy to your environment
3. Test the navigation flow: AI Hub → Teach AI tab → Q&A Training System link
4. Verify that the page loads smoothly without console errors

## Impact
- **Low Risk**: Simple component change with no logic modifications
- **High Benefit**: Fixes navigation failures and improves user experience
- **No Breaking Changes**: All existing functionality preserved