### PR TITLE
Fix: Add explicit type annotation for manuals array in downloadManual.ts

### DIFF
--- a/src/lib/tvDocs/downloadManual.ts
+++ b/src/lib/tvDocs/downloadManual.ts
@@ -192,7 +192,7 @@ export async function listDownloadedManuals(): Promise<Array<{ filename: string;
     await ensureManualsDirectory()
     
     const files = await fs.readdir(MANUALS_DIR)
-    const manuals = []
+    const manuals: Array<{ filename: string; size: number; path: string }> = []
     
     for (const file of files) {
       const filePath = path.join(MANUALS_DIR, file)


### PR DESCRIPTION
## Description
Fixes TypeScript build error in `src/lib/tvDocs/downloadManual.ts` at line 195 (previously line 202).

## Problem
The `manuals` array was being initialized without a type annotation, causing TypeScript to infer it as `never[]` instead of the correct type. This prevented proper type checking and caused build failures.

## Solution
Added explicit type annotation to the `manuals` array:
```typescript
const manuals: Array<{ filename: string; size: number; path: string }> = []
```

## Changes
- ✅ Added explicit type annotation matching the function's return type
- ✅ Maintains type safety throughout the function
- ✅ Resolves type inference issue

## Testing
- Verified the specific file compiles without the type inference error
- Type annotation matches the Promise return type of the function

## Impact
- **Risk Level**: Low (single line type annotation fix)
- **Breaking Changes**: None
- **Dependencies**: None