### PR TITLE
Fix TypeError in QA Training statistics page

### DIFF
--- a/src/lib/services/qa-generator.ts
+++ b/src/lib/services/qa-generator.ts
@@ -435,14 +435,18 @@ export async function getQAStatistics() {
   const total = await prisma.qAEntry.count();
   const active = await prisma.qAEntry.count({ where: { isActive: true } });
   
-  const byCategory = await prisma.qAEntry.groupBy({
+  const byCategoryRaw = await prisma.qAEntry.groupBy({
     by: ['category'],
-    _count: true,
+    _count: {
+      _all: true,
+    },
   });
 
-  const bySourceType = await prisma.qAEntry.groupBy({
+  const bySourceTypeRaw = await prisma.qAEntry.groupBy({
     by: ['sourceType'],
-    _count: true,
+    _count: {
+      _all: true,
+    },
   });
 
   const topUsed = await prisma.qAEntry.findMany({
@@ -456,6 +460,17 @@ export async function getQAStatistics() {
       category: true,
     },
   });
+
+  // Transform the groupBy results to match the expected format
+  const byCategory = byCategoryRaw.map(item => ({
+    category: item.category,
+    _count: item._count._all,
+  }));
+
+  const bySourceType = bySourceTypeRaw.map(item => ({
+    sourceType: item.sourceType,
+    _count: item._count._all,
+  }));
 
   return {
     total,


### PR DESCRIPTION
## Problem
When clicking the "Teach AI" link in the application, users were experiencing a TypeError related to the statistics display on the QA Training page.

## Root Cause
The issue was in the `getQAStatistics()` function in `src/lib/services/qa-generator.ts`. 

Prisma's `groupBy` method returns count data in the format:
```typescript
{ category: string, _count: { _all: number } }
```

However, the frontend TypeScript interface expected:
```typescript
{ category: string, _count: number }
```

This mismatch caused a TypeError when the frontend tried to access `_count` as a number instead of an object.

## Solution
Added a transformation step in `getQAStatistics()` to map the Prisma groupBy results to the expected format:

```typescript
const byCategory = byCategoryRaw.map(item => ({
  category: item.category,
  _count: item._count._all,
}));
```

This ensures the data structure matches what the frontend expects, eliminating the TypeError.

## Changes Made
- Modified `getQAStatistics()` in `src/lib/services/qa-generator.ts`
- Added transformation for both `byCategory` and `bySourceType` statistics
- Properly extracts `_count._all` value and flattens it to `_count`

## Testing
- ✅ Build completes successfully without TypeScript errors
- ✅ Statistics data structure now matches frontend interface expectations
- ✅ No breaking changes to existing functionality

## Impact
This fix resolves the TypeError that prevented users from accessing the QA Training page and viewing statistics about the AI training data.