### PR TITLE
Fix React hydration errors (#425, #418, #423)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,19 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import StreamingPlatformsWidget from '@/components/StreamingPlatformsWidget'
 import LayoutConfiguration from '@/components/LayoutConfiguration'
 import { Settings, Music } from 'lucide-react'
 
 export default function Home() {
   const [showLayoutConfig, setShowLayoutConfig] = useState(false)
+  const [currentTime, setCurrentTime] = useState<string>('')
+  
+  // Only render time on client side to avoid hydration mismatch
+  useEffect(() => {
+    setCurrentTime(new Date().toLocaleString())
+  }, [])
 
   return (
     <div className="min-h-screen bg-sports-gradient">
@@ -234,7 +240,7 @@ export default function Home() {
               <div className="text-center">
                 <div className="text-sm text-slate-300">Last Updated</div>
                 <div className="text-xs text-slate-400 mt-1">
-                  {new Date().toLocaleString()}
+                  {currentTime || 'Loading...'}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Fixed React hydration errors that were appearing in the browser console on the main dashboard page.

## Problem
The application was showing multiple React errors in the console:
- **React Error #425**: Text content mismatch between server and client
- **React Error #418**: Hydration mismatch causing client re-render
- **React Error #423**: Hydration failure with full root re-render

## Root Cause
The issue was caused by `new Date().toLocaleString()` on line 237 of `src/app/page.tsx`. This created a hydration mismatch because:
1. Server renders the page with one timestamp during build/SSR
2. Client hydrates with a different timestamp when the page loads
3. React detects the mismatch and throws hydration errors

## Solution
- Added `useEffect` hook to render the timestamp only on the client side after hydration completes
- Created `currentTime` state that initializes as empty string
- Shows "Loading..." placeholder during initial render to prevent mismatch
- Timestamp updates after component mounts on client side

## Changes
- Modified `src/app/page.tsx`:
  - Added `useEffect` import
  - Added `currentTime` state variable
  - Moved date rendering to `useEffect` hook
  - Updated JSX to use `currentTime` state with fallback

## Testing
- ✅ Build completes successfully without errors
- ✅ No React hydration warnings in console
- ✅ Timestamp displays correctly after page load
- ✅ All other functionality remains intact

## Impact
- Eliminates all React console errors on the main dashboard
- Improves application stability and performance
- Follows React best practices for SSR/hydration