### PR TITLE
Fix 500 Internal Server Error in enhanced-chat API endpoint

### DIFF
--- a/src/app/api/ai/enhanced-chat/route.ts
+++ b/src/app/api/ai/enhanced-chat/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
     
     let fullPrompt = message;
     let usedContext = false;
-    let contextError = null;
+    let contextError: string | null = null;
     
     // Add enhanced context (documentation + codebase) if enabled
     if (useKnowledge || useCodebase) {

--- a/src/app/api/ai/enhanced-chat/route.ts
+++ b/src/app/api/ai/enhanced-chat/route.ts
@@ -23,52 +23,83 @@ export async function POST(request: NextRequest) {
     
     let fullPrompt = message;
     let usedContext = false;
+    let contextError = null;
     
     // Add enhanced context (documentation + codebase) if enabled
     if (useKnowledge || useCodebase) {
-      const context = await buildEnhancedContext(
-        message,
-        useCodebase,
-        useKnowledge
-      );
-      
-      if (context) {
-        fullPrompt = context + '\nUser Question: ' + message;
-        usedContext = true;
+      try {
+        const context = await buildEnhancedContext(
+          message,
+          useCodebase,
+          useKnowledge
+        );
+        
+        if (context) {
+          fullPrompt = context + '\nUser Question: ' + message;
+          usedContext = true;
+        }
+      } catch (error) {
+        console.error('Error building context:', error);
+        contextError = error instanceof Error ? error.message : 'Unknown error';
+        // Continue without context rather than failing completely
       }
     }
     
     // Call Ollama API
-    const response = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model,
-        prompt: fullPrompt,
-        stream: false
-      })
-    });
-    
-    if (!response.ok) {
-      throw new Error(`Ollama API error: ${response.statusText}`);
+    try {
+      const response = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          prompt: fullPrompt,
+          stream: false
+        })
+      });
+      
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('Ollama API error:', response.status, errorText);
+        throw new Error(`Ollama API error: ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      
+      return NextResponse.json({
+        response: data.response,
+        model: data.model,
+        usedContext,
+        usedCodebase: useCodebase,
+        usedKnowledge: useKnowledge,
+        contextError
+      });
+    } catch (fetchError: any) {
+      // Check if it's a connection error to Ollama
+      if (fetchError.cause?.code === 'ECONNREFUSED' || fetchError.message?.includes('ECONNREFUSED')) {
+        console.error('Ollama service is not running:', fetchError);
+        return NextResponse.json(
+          { 
+            error: 'Ollama AI service is not running',
+            message: `Cannot connect to Ollama at ${OLLAMA_BASE_URL}. Please ensure Ollama is installed and running.`,
+            suggestion: 'Start Ollama by running: ollama serve',
+            ollamaUrl: OLLAMA_BASE_URL
+          },
+          { status: 503 }
+        );
+      }
+      throw fetchError;
     }
-    
-    const data = await response.json();
-    
-    return NextResponse.json({
-      response: data.response,
-      model: data.model,
-      usedContext,
-      usedCodebase: useCodebase,
-      usedKnowledge: useKnowledge
-    });
     
   } catch (error) {
     console.error('Error in enhanced chat:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Failed to process chat request';
     return NextResponse.json(
-      { error: 'Failed to process chat request' },
+      { 
+        error: errorMessage,
+        details: error instanceof Error ? error.stack : undefined
+      },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Problem
The `/api/ai/enhanced-chat` endpoint was returning a generic 500 Internal Server Error when users tried to use the AI Assistant chat feature. The error occurred because the Ollama AI service was not running, but the API didn't handle this gracefully.

## Root Cause
The API was attempting to connect to Ollama at `http://localhost:11434` without proper error handling for connection failures. When Ollama wasn't running, it would throw an `ECONNREFUSED` error that wasn't being caught properly, resulting in a generic 500 error.

## Solution
This PR adds comprehensive error handling to the enhanced-chat API endpoint:

1. **Graceful Ollama Connection Handling**: Added a try-catch block specifically for the Ollama fetch call that detects `ECONNREFUSED` errors
2. **Better Error Messages**: Returns a 503 Service Unavailable status with a clear, actionable error message when Ollama is not running
3. **Context Building Error Handling**: Wrapped the context building logic in try-catch to prevent failures from blocking the entire API
4. **Helpful User Guidance**: The error response now includes:
   - Clear error message explaining Ollama is not running
   - The Ollama URL being attempted
   - Suggestion to start Ollama with `ollama serve`

## Changes Made
- Modified `src/app/api/ai/enhanced-chat/route.ts`:
  - Added try-catch around `buildEnhancedContext()` to handle context building errors gracefully
  - Added nested try-catch around Ollama API fetch with specific handling for connection errors
  - Changed error response from 500 to 503 when Ollama is unavailable
  - Added `contextError` field to track context building issues
  - Improved error logging and response details

## Testing
Tested the endpoint with Ollama not running:
- ✅ Returns 503 status code (instead of 500)
- ✅ Returns clear error message about Ollama not running
- ✅ Includes helpful suggestion to start Ollama
- ✅ Server logs show proper error tracking

## Impact
- Users will now see a clear, actionable error message instead of a generic 500 error
- The API gracefully degrades when Ollama is unavailable
- Context building errors no longer crash the entire endpoint
- Better debugging information in server logs