### PR TITLE
Install to user home directory by default; make location configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,55 @@ Get started with a single command! This one-line installer will automatically se
 curl -sSL https://raw.githubusercontent.com/dfultonthebar/Sports-Bar-TV-Controller/main/install.sh | bash
 ```
 
+### Installation Location
+
+**By default, the application installs to your home directory:**
+- Installation path: `$HOME/Sports-Bar-TV-Controller`
+- Runs as your current user (no separate service user needed)
+- Simple permissions - no sudo required for most operations
+
+**For custom installation location:**
+```bash
+# Install to a specific directory
+curl -sSL https://raw.githubusercontent.com/dfultonthebar/Sports-Bar-TV-Controller/main/install.sh | INSTALL_DIR=/custom/path bash
+
+# System-wide installation (creates service user)
+curl -sSL https://raw.githubusercontent.com/dfultonthebar/Sports-Bar-TV-Controller/main/install.sh | INSTALL_DIR=/opt/sportsbar bash
+```
+
 ### Prerequisites
 - **Operating System**: Ubuntu 20.04+ or Debian 11+ (64-bit)
-- **User Access**: sudo privileges required
+- **User Access**: sudo privileges recommended (but not required for home directory install)
 - **Network**: Active internet connection
 - **Disk Space**: At least 2GB free space
 
 ### What Gets Installed
 The installer automatically handles:
 - ✅ Node.js 20.x (via NodeSource repository)
-- ✅ PostgreSQL database
+- ✅ SQLite database (no separate database server needed)
 - ✅ All project dependencies
-- ✅ System service configuration
-- ✅ Automatic startup on boot
+- ✅ System service configuration (optional, requires sudo)
+- ✅ Automatic startup on boot (optional)
 
 ### After Installation
 Once complete, access your application at:
 - **Local**: http://localhost:3000
 - **Network**: http://[your-server-ip]:3000
 
-The service runs automatically in the background. Use these commands to manage it:
+**If systemd service was configured:**
 ```bash
-sudo systemctl status sportsbar    # Check status
-sudo systemctl restart sportsbar   # Restart service
-sudo systemctl stop sportsbar      # Stop service
-sudo systemctl start sportsbar     # Start service
+sudo systemctl status sportsbar-assistant    # Check status
+sudo systemctl restart sportsbar-assistant   # Restart service
+sudo systemctl stop sportsbar-assistant      # Stop service
+sudo systemctl start sportsbar-assistant     # Start service
+```
+
+**If running manually (no systemd service):**
+```bash
+cd ~/Sports-Bar-TV-Controller
+npm start                          # Start in production mode
+# or
+npm run dev                        # Start in development mode
 ```
 
 ---
@@ -49,9 +73,11 @@ sudo systemctl start sportsbar     # Start service
 Use the automated update script to pull latest changes without any yarn issues:
 
 ```bash
-cd /home/ubuntu/Sports-Bar-TV-Controller
+cd ~/Sports-Bar-TV-Controller
 ./update_from_github.sh
 ```
+
+**Note:** If you installed to a custom location, replace `~/Sports-Bar-TV-Controller` with your installation directory.
 
 This script automatically:
 - **Creates automatic backup** of all your settings
@@ -135,7 +161,7 @@ Automatic backups are created before every update as a safety net. You only need
 For a completely clean installation:
 
 ```bash
-cd /home/ubuntu
+cd ~
 ./fresh_install.sh
 ```
 
@@ -144,7 +170,7 @@ cd /home/ubuntu
 If you're updating from an old installation that still has yarn issues:
 
 ```bash
-cd /home/ubuntu/Sports-Bar-TV-Controller
+cd ~/Sports-Bar-TV-Controller
 ./permanent_fix_yarn.sh
 ```
 
@@ -155,7 +181,7 @@ This converts your existing installation to use npm permanently.
 If you prefer manual control:
 
 ```bash
-cd /home/ubuntu/Sports-Bar-TV-Controller
+cd ~/Sports-Bar-TV-Controller
 git pull origin main
 npm install
 npx prisma generate


### PR DESCRIPTION
## Summary
This PR fixes the installation confusion by changing the default installation location from `/opt/sportsbar` to the user's home directory (`$HOME/Sports-Bar-TV-Controller`), making the installation more intuitive and user-friendly.

## Changes Made

### Installation Script (`install.sh`)
- **Default location changed**: Now installs to `$HOME/Sports-Bar-TV-Controller` instead of `/opt/sportsbar`
- **Configurable installation**: Added `INSTALL_DIR` environment variable for custom paths
- **Smart user detection**: Automatically determines if a service user is needed based on installation path
  - Home directory installs: Use current user (no service user needed)
  - System paths (`/opt/*`, `/usr/*`): Create dedicated service user
- **Simplified permissions**: Home directory installations don't require complex ownership changes
- **Optional systemd service**: Service setup is now optional and adapts to installation type
- **Better sudo handling**: Works with or without sudo for home directory installations
- **Improved error messages**: Clear guidance on manual startup if systemd isn't configured

### Documentation (`README.md`)
- **Clear installation location section**: Prominently documents where the app installs
- **Custom installation examples**: Shows how to specify custom directories
- **Updated all path references**: Changed from `/home/ubuntu/Sports-Bar-TV-Controller` to `~/Sports-Bar-TV-Controller`
- **Dual startup instructions**: Documents both systemd service and manual startup methods
- **Prerequisites clarification**: Sudo is recommended but not required for home installs

## Benefits
1. **More intuitive**: Users expect installations to go to their home directory by default
2. **Simpler permissions**: No need for service users or complex ownership for personal use
3. **Flexible**: Still supports system-wide installations when needed
4. **Better UX**: Clear documentation prevents confusion about installation location
5. **Backward compatible**: System admins can still use `/opt` or custom paths

## Testing Recommendations
- Test default installation (should go to `$HOME/Sports-Bar-TV-Controller`)
- Test custom path: `INSTALL_DIR=/custom/path bash install.sh`
- Test system-wide: `INSTALL_DIR=/opt/sportsbar bash install.sh`
- Verify permissions are correct for each installation type
- Test with and without sudo access
- Verify systemd service works when configured
- Verify manual startup works when systemd is skipped

## Migration Notes
For users with existing installations at `/opt/sportsbar`:
- The old installation will continue to work
- New installations will default to home directory
- Users can specify `INSTALL_DIR=/opt/sportsbar` to maintain old behavior
- Consider documenting migration path in release notes