### PR TITLE
Fix: Create .env file before database migrations in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -690,8 +690,8 @@ main() {
     create_service_user
     clone_repository
     install_app_dependencies
-    setup_database
     configure_environment
+    setup_database
     build_application
     setup_pm2
     set_permissions


### PR DESCRIPTION
## Problem

The installation script was hanging/timing out during the database migration step. Investigation revealed that the `.env` file (containing the `DATABASE_URL` environment variable) was being created **after** the database setup function was called.

### Root Cause
- Prisma's `migrate deploy` command requires `DATABASE_URL` to be set in the environment
- The script execution order was:
  1. `install_app_dependencies`
  2. `setup_database` ← **Runs migrations WITHOUT DATABASE_URL**
  3. `configure_environment` ← **Creates .env file with DATABASE_URL**
- This caused `npx prisma migrate deploy` to fail/timeout because it couldn't find the database connection string

### Evidence
From user's installation logs:
```
error: Environment variable not found: DATABASE_URL
```

Multiple Prisma errors during build about missing DATABASE_URL, and the migration step would hang for 60 seconds before timing out.

## Solution

**Simple one-line fix:** Swap the order of function calls to create the `.env` file **before** running database migrations.

### Changes
- Moved `configure_environment()` call before `setup_database()` call in the main installation flow
- This ensures `DATABASE_URL` is available when running `npx prisma migrate deploy`

```diff
    install_app_dependencies
-   setup_database
    configure_environment
+   setup_database
    build_application
```

## Testing

✅ **Verified on production system:**
- Ubuntu system (Intel NUC - hostname: tvcontroller)
- Manual installation with correct order completed successfully
- Application running properly with PM2
- Database migrations completed without timeout
- No environment variable errors

✅ **What now works:**
- `npx prisma migrate deploy` completes successfully
- No 60-second timeout during migration
- Build process completes without DATABASE_URL warnings
- Application starts and connects to database properly

## Impact

- **Low risk:** Only changes the order of function calls, no logic changes
- **High benefit:** Fixes critical installation failure that prevented automated deployment
- **Backwards compatible:** Existing installations are unaffected

## Additional Notes

The `.env` file is created from `.env.example` and sets:
- `DATABASE_URL="file:./prisma/data/sports_bar.db"`
- `OLLAMA_BASE_URL="http://localhost:11434"`

This fix ensures these environment variables are available to all subsequent installation steps, particularly the database migration process.

---

**Fixes:** Installation script hanging at database migration step
**Related:** Database setup, Prisma migrations, environment configuration