### PR TITLE
Fix: Add missing QA generator exports and PM2 PATH configuration

### DIFF
--- a/fix-pm2-path.sh
+++ b/fix-pm2-path.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Fix PM2 PATH issue
+# This script adds PM2 to the system PATH permanently
+
+set -e
+
+echo "🔧 Fixing PM2 PATH configuration..."
+echo ""
+
+# Check if PM2 is installed
+if ! npm list -g pm2 &>/dev/null; then
+    echo "❌ PM2 is not installed globally"
+    echo "   Installing PM2..."
+    npm install -g pm2
+fi
+
+# Get npm global bin path
+NPM_GLOBAL_BIN=$(npm bin -g)
+echo "📍 NPM global bin path: $NPM_GLOBAL_BIN"
+
+# Check if already in PATH
+if echo "$PATH" | grep -q "$NPM_GLOBAL_BIN"; then
+    echo "✅ PM2 is already in PATH"
+else
+    echo "➕ Adding PM2 to PATH..."
+    
+    # Add to .bashrc
+    if ! grep -q "npm bin -g" ~/.bashrc; then
+        echo "" >> ~/.bashrc
+        echo "# Add npm global binaries to PATH" >> ~/.bashrc
+        echo 'export PATH="$(npm bin -g):$PATH"' >> ~/.bashrc
+        echo "✅ Added to ~/.bashrc"
+    fi
+    
+    # Add to .profile
+    if ! grep -q "npm bin -g" ~/.profile; then
+        echo "" >> ~/.profile
+        echo "# Add npm global binaries to PATH" >> ~/.profile
+        echo 'export PATH="$(npm bin -g):$PATH"' >> ~/.profile
+        echo "✅ Added to ~/.profile"
+    fi
+    
+    # Export for current session
+    export PATH="$NPM_GLOBAL_BIN:$PATH"
+    echo "✅ Exported for current session"
+fi
+
+echo ""
+echo "🧪 Testing PM2 command..."
+if command -v pm2 &>/dev/null; then
+    echo "✅ PM2 is now accessible: $(which pm2)"
+    echo "   Version: $(pm2 --version)"
+else
+    echo "⚠️  PM2 not yet in PATH for this session"
+    echo "   Run: source ~/.bashrc"
+    echo "   Or start a new terminal session"
+fi
+
+echo ""
+echo "✅ PM2 PATH fix complete!"
+echo ""
+echo "📝 Next steps:"
+echo "   1. Run: source ~/.bashrc"
+echo "   2. Verify: pm2 --version"
+echo "   3. Check PM2 processes: pm2 status"


### PR DESCRIPTION
## Problem
The user encountered errors during the update process:

1. **Build Warnings**: Missing exports in `qa-generator.ts` causing import errors in `/api/ai/qa-entries` route
2. **PM2 PATH Issue**: PM2 installed but not accessible via command line, preventing proper process management

## Root Cause Analysis

### Build Warnings
The API route `/api/ai/qa-entries/route.ts` was importing 5 functions that didn't exist:
- `getAllQAEntries`
- `searchQAEntries` 
- `updateQAEntry`
- `deleteQAEntry`
- `getQAStatistics`

Only 2 functions were exported from `qa-generator.ts`:
- `generateQAsFromRepository`
- `getQAGenerationStatus`

### PM2 PATH Issue
PM2 was installed in `~/.npm-global/lib` but not added to the system PATH, causing:
- `pm2: command not found` errors during updates
- Inability to manage PM2 processes from command line
- Failed PM2 startup configuration

## Solution

### 1. Added Missing QA Generator Functions
Added 5 missing exported functions to `src/lib/services/qa-generator.ts`:

- **`getAllQAEntries`**: Retrieve all Q&A entries with optional filtering by category, sourceType, with pagination support
- **`searchQAEntries`**: Search Q&A entries by query string across questions, answers, and tags
- **`updateQAEntry`**: Update existing Q&A entry fields (question, answer, category, tags, confidence, verification status)
- **`deleteQAEntry`**: Delete a Q&A entry by ID
- **`getQAStatistics`**: Get comprehensive statistics including total entries, verified counts, category distribution, source type distribution, and recent generation jobs

### 2. Created PM2 PATH Fix Script
Created `fix-pm2-path.sh` that:
- Detects npm global bin path
- Adds it to `~/.bashrc` and `~/.profile`
- Exports PATH for current session
- Verifies PM2 is accessible
- Provides clear next steps for the user

## Testing
- ✅ All missing exports now present in qa-generator.ts
- ✅ Functions follow existing code patterns and use Prisma client
- ✅ PM2 PATH fix script is executable and well-documented
- ✅ Build warnings will be resolved once merged

## Impact
- **Build**: Eliminates 5 import warnings during Next.js build
- **Functionality**: Enables Q&A entry management features in the AI Hub
- **Operations**: Fixes PM2 command accessibility for process management
- **User Experience**: Smoother updates without PATH-related errors

## Files Changed
- `src/lib/services/qa-generator.ts` (+155 lines): Added 5 missing exported functions
- `fix-pm2-path.sh` (+66 lines): New script to fix PM2 PATH configuration

## Deployment Notes
After merging, users should:
1. Pull the latest changes
2. Run `./fix-pm2-path.sh` to fix PM2 PATH
3. Run `source ~/.bashrc` to apply PATH changes
4. Rebuild the application to clear build warnings

## Related Issues
- Fixes build warnings reported in error log
- Resolves PM2 command not found errors during updates
- Enables Q&A training features in AI Hub