### PR TITLE
Fix port conflict and getGenerationJobStatus import error

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -10,7 +10,7 @@ module.exports = {
     max_memory_restart: '1G',
     env: {
       NODE_ENV: 'production',
-      PORT: 3000
+      PORT: 3001
     }
   }]
 }

--- a/src/app/api/ai/qa-generate/route.ts
+++ b/src/app/api/ai/qa-generate/route.ts
@@ -1,6 +1,6 @@
 
 import { NextRequest, NextResponse } from 'next/server';
-import { generateQAsFromRepository, getGenerationJobStatus } from '@/lib/services/qa-generator';
+import { generateQAsFromRepository, getQAGenerationStatus } from '@/lib/services/qa-generator';
 
 export async function POST(request: NextRequest) {
   try {
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const status = await getGenerationJobStatus(jobId);
+    const status = await getQAGenerationStatus(jobId);
 
     if (!status) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
This PR fixes two critical issues preventing the application from running properly:

### Issue 1: Port Conflict (EADDRINUSE)
**Problem:** PM2 was crashing with `EADDRINUSE: address already in use :::3000` because both `sports-bar-tv-controller` and `sportsbar-assistant` were trying to use port 3000.

**Solution:** Changed `sports-bar-tv-controller` to use port 3001 in `ecosystem.config.js`.

### Issue 2: getGenerationJobStatus Import Error
**Problem:** Runtime error `TypeError: (0 , u.getGenerationJobStatus) is not a function` in the Q&A generation API.

**Solution:** Fixed import/export mismatch by changing the import from `getGenerationJobStatus` to `getQAGenerationStatus` (the actual exported function name) in `src/app/api/ai/qa-generate/route.ts`.

## Changes
- `ecosystem.config.js`: Changed PORT from 3000 to 3001
- `src/app/api/ai/qa-generate/route.ts`: Fixed function import name to match actual export

## Deployment Instructions

### Step 1: Pull and Rebuild
```bash
cd ~/Sports-Bar-TV-Controller
git pull origin main
npm install
npm run build
```

### Step 2: Stop Current PM2 Processes
```bash
pm2 stop all
pm2 delete all
```

### Step 3: Start with Updated Configuration
```bash
pm2 start ecosystem.config.js
pm2 save
```

### Step 4: Verify Both Apps Running
```bash
pm2 status
```

Expected output:
- `sports-bar-tv-controller` running on port 3001 ✅
- `sportsbar-assistant` running on port 3000 ✅

### Step 5: Test Q&A Generation
The Q&A generation API should now work without the TypeError.

## Notes
- The build is already up-to-date, so rebuild should be fast
- Both apps will now run on separate ports without conflicts
- Q&A generation workers (3 concurrent) will function properly