### PR TITLE
fix: Replace isVerified with isActive in Q&A statistics query

### DIFF
--- a/src/lib/services/qa-generator.ts
+++ b/src/lib/services/qa-generator.ts
@@ -564,7 +564,7 @@ export async function updateQAEntry(
     category?: string;
     tags?: string[];
     confidence?: number;
-    isVerified?: boolean;
+    isActive?: boolean;
   }
 ) {
   return await prisma.qAEntry.update({
@@ -597,7 +597,7 @@ export async function getQAStatistics() {
     recentJobs,
   ] = await Promise.all([
     prisma.qAEntry.count(),
-    prisma.qAEntry.count({ where: { isVerified: true } }),
+    prisma.qAEntry.count({ where: { isActive: true } }),
     prisma.qAEntry.groupBy({
       by: ['category'],
       _count: true,


### PR DESCRIPTION
## 🐛 Bug Fix: Q&A Statistics Query Error

### Problem
The application was experiencing a `PrismaClientValidationError` when fetching Q&A statistics:

```
Error fetching Q&A statistics: PrismaClientValidationError:
Invalid `prisma.qAEntry.count()` invocation:
Unknown argument `isVerified`. Available options are marked with ?.
```

**Error Location:** `/api/ai/qa-entries` route  
**Root Cause:** Code was using `isVerified` field, but the Prisma schema defines it as `isActive`

### Solution
✅ Replaced all occurrences of `isVerified` with `isActive` to match the Prisma schema

### Changes Made

**File:** `src/lib/services/qa-generator.ts`

1. **Line 567** - Function parameter in `updateQAEntry()`:
   ```typescript
   // Before
   isVerified?: boolean;
   
   // After
   isActive?: boolean;
   ```

2. **Line 600** - Query in `getQAStatistics()`:
   ```typescript
   // Before
   prisma.qAEntry.count({ where: { isVerified: true } })
   
   // After
   prisma.qAEntry.count({ where: { isActive: true } })
   ```

### Prisma Schema Reference
From `prisma/schema.prisma` (line 561):
```prisma
model QAEntry {
  id           String    @id @default(cuid())
  question     String
  answer       String
  category     String    @default("general")
  tags         String?
  sourceType   String    @default("manual")
  sourceFile   String?
  confidence   Float     @default(1.0)
  isActive     Boolean   @default(true)  // ← Correct field name
  usageCount   Int       @default(0)
  lastUsed     DateTime?
  createdAt    DateTime  @default(now())
  updatedAt    DateTime  @updatedAt
}
```

### Impact
- ✅ Fixes Q&A statistics API endpoint
- ✅ Allows Q&A generation system to function properly
- ✅ No breaking changes - aligns code with existing schema

### Testing Recommendations
1. **Verify Q&A statistics endpoint works:**
   ```bash
   curl http://localhost:3001/api/ai/qa-entries
   ```

2. **Check application logs for errors:**
   ```bash
   pm2 logs sports-bar-tv-controller --lines 50
   ```

3. **Verify Q&A generation is working:**
   - Check that Q&A entries are being created
   - Verify statistics are being calculated correctly

### Deployment Instructions

**For the user's local installation at `~/Sports-Bar-TV-Controller`:**

```bash
# 1. Navigate to the installation directory
cd ~/Sports-Bar-TV-Controller

# 2. Pull the latest changes (after PR is merged)
git pull origin main

# 3. Rebuild the application
npm run build

# 4. Restart PM2 with proper lifecycle management
pm2 stop all
pm2 delete all
pm2 start ecosystem.config.js
pm2 save

# 5. Verify the app is running
pm2 status
pm2 logs sports-bar-tv-controller --lines 20

# 6. Test the Q&A statistics endpoint
curl http://localhost:3001/api/ai/qa-entries
```

**Alternative: Use the updated deployment script (from PR #141):**
```bash
cd ~/Sports-Bar-TV-Controller
./update_from_github.sh
```

### Verification Steps
After deployment, verify the fix worked:

1. **Check for the error in logs:**
   ```bash
   pm2 logs sports-bar-tv-controller --lines 100 | grep "isVerified"
   ```
   Should return no results.

2. **Verify Q&A statistics are loading:**
   ```bash
   curl http://localhost:3001/api/ai/qa-entries | jq
   ```
   Should return valid JSON with statistics.

3. **Check application health:**
   ```bash
   pm2 status
   curl http://localhost:3001/api/health
   ```

### Files Changed
- ✅ `src/lib/services/qa-generator.ts` (2 occurrences fixed)

### Related Issues
- Fixes the `PrismaClientValidationError` reported in application logs
- Resolves Q&A statistics query failures
- Enables proper Q&A generation system functionality

---

**Ready to merge** - This is a critical bug fix that aligns the code with the Prisma schema.