### PR TITLE
Fix Prisma validation error: Remove unsupported 'mode' argument from SQLite queries

### DIFF
--- a/src/lib/firecube/sports-content-detector.ts
+++ b/src/lib/firecube/sports-content-detector.ts
@@ -225,10 +225,10 @@ export class SportsContentDetector {
         where: {
           deviceId,
           OR: [
-            { contentTitle: { contains: query, mode: 'insensitive' } },
-            { league: { contains: query, mode: 'insensitive' } },
-            { teams: { contains: query, mode: 'insensitive' } },
-            { description: { contains: query, mode: 'insensitive' } }
+            { contentTitle: { contains: query } },
+            { league: { contains: query } },
+            { teams: { contains: query } },
+            { description: { contains: query } }
           ]
         },
         orderBy: {
@@ -250,8 +250,7 @@ export class SportsContentDetector {
         where: {
           deviceId,
           league: {
-            equals: league,
-            mode: 'insensitive'
+            equals: league
           }
         },
         orderBy: {

--- a/src/lib/services/qa-generator.ts
+++ b/src/lib/services/qa-generator.ts
@@ -526,8 +526,8 @@ export async function searchQAEntries(query: string, filters?: {
 }) {
   const where: any = {
     OR: [
-      { question: { contains: query, mode: 'insensitive' } },
-      { answer: { contains: query, mode: 'insensitive' } },
+      { question: { contains: query } },
+      { answer: { contains: query } },
       { tags: { has: query } },
     ],
   };


### PR DESCRIPTION
## Problem
After deploying the fix for the `isVerified` → `isActive` field error, a new Prisma validation error appeared in the enhanced-chat route:

```
Unknown argument `mode`. Did you mean `lte`? Available options are marked with ?.
```

## Root Cause
The codebase was using `mode: 'insensitive'` parameter in Prisma queries for case-insensitive string matching. However, **SQLite does not support the `mode` parameter** - this feature is only available for PostgreSQL and MongoDB databases.

## Solution
Removed all instances of `mode: 'insensitive'` from Prisma queries in:
1. **src/lib/services/qa-generator.ts** - `searchQAEntries()` function
2. **src/lib/firecube/sports-content-detector.ts** - `searchContent()` and `getContentByLeague()` functions

## Changes Made
- ✅ Removed `mode: 'insensitive'` from `contains` queries
- ✅ Removed `mode: 'insensitive'` from `equals` queries
- ✅ All Prisma queries now use SQLite-compatible syntax

## Impact
⚠️ **Note:** Search functionality will now be **case-sensitive** with SQLite. 

For example:
- Before: Searching "ESPN" would match "espn", "ESPN", "EsPn"
- After: Searching "ESPN" will only match "ESPN" exactly

### Future Enhancement Options
If case-insensitive search is required, consider:
1. Converting search terms to lowercase in application code
2. Storing lowercase versions of searchable fields
3. Migrating to PostgreSQL (supports `mode: 'insensitive'`)

## Testing
After deployment:
1. The enhanced-chat route should work without Prisma validation errors
2. Q&A search functionality will work (case-sensitive)
3. FireCube sports content search will work (case-sensitive)

## Files Changed
- `src/lib/services/qa-generator.ts`
- `src/lib/firecube/sports-content-detector.ts`

## Related Issues
- Fixes the Prisma validation error in `/api/ai/enhanced-chat` route
- Follows up on the previous `isVerified` → `isActive` fix