### PR TITLE
Fix: Correct API endpoint for Wolfpack configuration save (405 error)

### DIFF
--- a/src/components/MatrixControl.tsx
+++ b/src/components/MatrixControl.tsx
@@ -115,7 +115,7 @@ export default function MatrixControl() {
   const fetchConfigurations = async () => {
     setIsLoading(true)
     try {
-      const response = await fetch('/api/matrix-config')
+      const response = await fetch('/api/matrix/config')
       const data = await response.json()
       
       if (response.ok) {
@@ -176,7 +176,7 @@ export default function MatrixControl() {
   const saveConfiguration = async () => {
     setIsLoading(true)
     try {
-      const response = await fetch('/api/matrix-config', {
+      const response = await fetch('/api/matrix/config', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
Fixes the 405 Method Not Allowed error when saving Wolfpack configurations by correcting the API endpoint from `/api/matrix-config` to `/api/matrix/config`.

## Changes
- Updated MatrixControl component to use the correct API endpoint `/api/matrix/config` in 2 locations
- Resolves 405 error that was preventing Wolfpack configuration saves

## Testing
- Verified endpoint change aligns with backend routing
- Configuration save operations should now work correctly