### PR TITLE
Fix: Add missing react-hot-toast dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "pdf-parse": "^1.1.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hot-toast": "^2.4.1",
         "recharts": "^3.2.1",
         "sharp": "^0.34.4",
         "tailwind-merge": "^3.3.1",
@@ -3984,7 +3985,6 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -5593,6 +5593,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -7666,6 +7675,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "tailwind-merge": "^3.3.1",
     "tough-cookie": "^5.0.0",
     "uuid": "^13.0.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "react-hot-toast": "^2.4.1"
   },
   "optionalDependencies": {
     "isolated-vm": "^6.0.1"


### PR DESCRIPTION
## Problem
After merging PR #162, the build is failing with:
```
Module not found: Can't resolve 'react-hot-toast'
Import trace for requested module:
./src/app/matrix-control/page.tsx
```

The `MatrixControl.tsx` component imports `react-hot-toast` but this dependency was not listed in `package.json`.

## Solution
- Adds `react-hot-toast@^2.4.1` to dependencies
- Updates `package-lock.json` accordingly

## Testing
This fix resolves the build error and allows the application to build successfully.

## Related
- Fixes build error introduced in PR #162