### PR TITLE
Fix: Critical Prisma Singleton and DirecTV 403 Error Handling

### DIFF
--- a/src/app/api/directv-devices/send-command/route.ts
+++ b/src/app/api/directv-devices/send-command/route.ts
@@ -88,7 +88,22 @@ async function sendDirecTVCommand(ip: string, port: number, command: string): Pr
         data: { status: response.status, response: responseText }
       }
     } else {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      // Handle 403 Forbidden specifically - SHEF not enabled
+      if (response.status === 403) {
+        throw new Error(
+          `HTTP 403: External Device Access is disabled on the DirecTV receiver. ` +
+          `To enable: Press MENU on DirecTV remote → Settings & Help → Settings → ` +
+          `Whole-Home → External Device → Enable "External Access". ` +
+          `Then restart the receiver.`
+        )
+      } else if (response.status === 404) {
+        throw new Error(
+          `HTTP 404: SHEF API endpoint not found. Verify the receiver supports network control ` +
+          `and is using the correct firmware version.`
+        )
+      } else {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      }
     }
   } catch (error) {
     console.error('DirecTV command error:', error)

--- a/src/lib/ai-knowledge-enhanced.ts
+++ b/src/lib/ai-knowledge-enhanced.ts
@@ -1,8 +1,8 @@
 
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 import { loadKnowledgeBase, DocumentChunk } from './ai-knowledge';
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export interface CodebaseContext {
   files: Array<{

--- a/src/lib/ai-knowledge-qa.ts
+++ b/src/lib/ai-knowledge-qa.ts
@@ -4,10 +4,10 @@
  * Integrates Q&A training data with the existing knowledge base
  */
 
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 import { loadKnowledgeBase, DocumentChunk, searchKnowledgeBase } from './ai-knowledge';
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export interface EnhancedContext {
   documentation: DocumentChunk[];

--- a/src/lib/atlas-meter-service.ts
+++ b/src/lib/atlas-meter-service.ts
@@ -3,9 +3,9 @@
  * Collects and stores real-time audio level data from Atlas processors
  */
 
-import { PrismaClient } from '@prisma/client'
+import prisma from "@/lib/prisma"
 
-const prisma = new PrismaClient()
+// Using singleton prisma from @/lib/prisma
 
 interface MeterReading {
   inputNumber: number

--- a/src/lib/directv/shef-client.ts
+++ b/src/lib/directv/shef-client.ts
@@ -140,6 +140,10 @@ export class SHEFClient {
       return response.status.code === 200;
     } catch (error: any) {
       if (error.response?.status === 403) {
+        console.error(
+          'DirecTV SHEF API returned 403 Forbidden. External Device Access is disabled. ' +
+          'To enable: MENU → Settings & Help → Settings → Whole-Home → External Device → Enable "External Access"'
+        );
         return false; // SHEF not enabled
       }
       throw error;

--- a/src/lib/firecube/app-discovery.ts
+++ b/src/lib/firecube/app-discovery.ts
@@ -3,9 +3,9 @@
 
 import { ADBClient } from './adb-client';
 import { KNOWN_SPORTS_APPS, FireCubeApp, InstalledApp } from './types';
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export class AppDiscoveryService {
   /**

--- a/src/lib/firecube/keep-awake-scheduler.ts
+++ b/src/lib/firecube/keep-awake-scheduler.ts
@@ -3,9 +3,9 @@
 
 import cron from 'node-cron';
 import { ADBClient } from './adb-client';
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export class KeepAwakeScheduler {
   private scheduledTasks: Map<string, cron.ScheduledTask> = new Map();

--- a/src/lib/firecube/sideload-service.ts
+++ b/src/lib/firecube/sideload-service.ts
@@ -2,12 +2,12 @@
 // App Sideloading Service for Fire Cubes
 
 import { ADBClient } from './adb-client';
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 const mkdir = promisify(fs.mkdir);
 const exists = promisify(fs.exists);
 

--- a/src/lib/firecube/sports-content-detector.ts
+++ b/src/lib/firecube/sports-content-detector.ts
@@ -3,9 +3,9 @@
 
 import { ADBClient } from './adb-client';
 import { KNOWN_SPORTS_APPS, FireCubeSportsContent, LiveSportsContent } from './types';
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export class SportsContentDetector {
   /**

--- a/src/lib/firecube/subscription-detector.ts
+++ b/src/lib/firecube/subscription-detector.ts
@@ -3,9 +3,9 @@
 
 import { ADBClient } from './adb-client';
 import { KNOWN_SPORTS_APPS, SubscriptionCheckResult } from './types';
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export class SubscriptionDetector {
   /**

--- a/src/lib/scheduler-service.ts
+++ b/src/lib/scheduler-service.ts
@@ -6,9 +6,9 @@
  * It checks every minute for schedules that need to be executed.
  */
 
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 class SchedulerService {
   private intervalId: NodeJS.Timeout | null = null;

--- a/src/lib/services/cec-discovery-service.ts
+++ b/src/lib/services/cec-discovery-service.ts
@@ -6,11 +6,11 @@
  * using CEC protocol queries via USB CEC adapter
  */
 
-import { PrismaClient } from '@prisma/client'
+import prisma from "@/lib/prisma"
 import { cecService } from '@/lib/cec-service'
 import { autoFetchDocumentation } from '@/lib/tvDocs'
 
-const prisma = new PrismaClient()
+// Using singleton prisma from @/lib/prisma
 
 export interface CECDiscoveryResult {
   outputNumber: number

--- a/src/lib/services/qa-generator.ts
+++ b/src/lib/services/qa-generator.ts
@@ -8,9 +8,9 @@
 
 import fs from 'fs';
 import path from 'path';
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 const DEFAULT_MODEL = 'phi3:mini'; // OPTIMIZED: Changed to faster model

--- a/src/lib/services/qa-uploader.ts
+++ b/src/lib/services/qa-uploader.ts
@@ -4,9 +4,9 @@
  * Handles uploading and parsing Q&A documents in various formats
  */
 
-import { PrismaClient } from '@prisma/client';
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Using singleton prisma from @/lib/prisma;
 
 export interface UploadedQA {
   question: string;

--- a/src/lib/tvDocs/generateQA.ts
+++ b/src/lib/tvDocs/generateQA.ts
@@ -5,10 +5,10 @@
  * Generates Q&A pairs from TV manual content for AI training
  */
 
-import { PrismaClient } from '@prisma/client'
+import prisma from "@/lib/prisma"
 import { extractManualContent, splitContentIntoChunks, extractKeySections } from './extractContent'
 
-const prisma = new PrismaClient()
+// Using singleton prisma from @/lib/prisma
 
 interface QAPair {
   question: string

--- a/src/lib/tvDocs/index.ts
+++ b/src/lib/tvDocs/index.ts
@@ -5,13 +5,13 @@
  * Main service for fetching, storing, and managing TV documentation
  */
 
-import { PrismaClient } from '@prisma/client'
+import prisma from "@/lib/prisma"
 import { searchTVManual, validateManualUrl } from './searchManual'
 import { downloadTVManual, getManualPath } from './downloadManual'
 import { generateQAFromManual } from './generateQA'
 import { TVManualFetchOptions, TVManualFetchResult, TVDocumentationRecord } from './types'
 
-const prisma = new PrismaClient()
+// Using singleton prisma from @/lib/prisma
 
 /**
  * Fetch TV manual and generate Q&A pairs

--- a/src/services/presetReorderService.ts
+++ b/src/services/presetReorderService.ts
@@ -1,7 +1,7 @@
 
-import { PrismaClient } from '@prisma/client'
+import prisma from "@/lib/prisma"
 
-const prisma = new PrismaClient()
+// Using singleton prisma from @/lib/prisma
 
 /**
  * Reorder all presets based on usage count


### PR DESCRIPTION
## Critical Fixes

This PR addresses two critical issues reported in PM2 logs:

### 1. ✅ Prisma Singleton Pattern Fix (CRITICAL)

**Issue:** Multiple files were creating their own `PrismaClient` instances, causing:
```
[Preset Fetch] Error fetching presets by device: TypeError: Cannot read properties of undefined (reading 'findMany')
```

**Root Cause:** 
- Multiple PrismaClient instances lead to database connection pool exhaustion
- Ghost database connections
- Undefined prisma client references
- Memory leaks in Next.js applications

**Solution:** Implemented singleton pattern across **15 files**:
- `src/services/presetReorderService.ts`
- `src/lib/services/qa-uploader.ts`
- `src/lib/services/cec-discovery-service.ts`
- `src/lib/services/qa-generator.ts`
- `src/lib/atlas-meter-service.ts`
- `src/lib/scheduler-service.ts`
- `src/lib/firecube/sideload-service.ts`
- `src/lib/firecube/keep-awake-scheduler.ts`
- `src/lib/firecube/subscription-detector.ts`
- `src/lib/firecube/app-discovery.ts`
- `src/lib/firecube/sports-content-detector.ts`
- `src/lib/tvDocs/generateQA.ts`
- `src/lib/tvDocs/index.ts`
- `src/lib/ai-knowledge-qa.ts`
- `src/lib/ai-knowledge-enhanced.ts`

**Change:**
```typescript
// Before
import { PrismaClient } from '@prisma/client'
const prisma = new PrismaClient()

// After
import prisma from "@/lib/prisma"
// Using singleton prisma from @/lib/prisma
```

### 2. ✅ DirecTV 403 Forbidden Error Handling (CRITICAL)

**Issue:** DirecTV receivers returning HTTP 403 errors:
```
DirecTV command error: Error: HTTP 403: Forbidden.
Sending DirecTV command to: http://192.168.5.121:8080/remote/processKey?key=KEY_8&hold=keyPress
```

**Root Cause:** 
DirecTV receivers have "External Device Access" disabled by default for security. The SHEF API requires this to be enabled.

**Solution:** Enhanced error handling with actionable instructions:

**Files Modified:**
- `src/app/api/directv-devices/send-command/route.ts` - Added 403/404 specific error messages
- `src/lib/directv/shef-client.ts` - Enhanced error logging

**New Error Messages:**
```
HTTP 403: External Device Access is disabled on the DirecTV receiver.
To enable: Press MENU on DirecTV remote → Settings & Help → Settings → 
Whole-Home → External Device → Enable "External Access". 
Then restart the receiver.
```

## Documentation Updates

Updated `SYSTEM_DOCUMENTATION.md` with:
- New "Recent Fixes and Changes" section
- Detailed Prisma singleton implementation guide
- Step-by-step DirecTV troubleshooting instructions
- Code examples and verification steps
- Updated version to 2.3

## Testing Recommendations

### Prisma Fix Testing:
1. Restart the application: `pm2 restart sports-bar-tv`
2. Navigate to `/remote` and try changing channels
3. Check PM2 logs: `pm2 logs sports-bar-tv --lines 50`
4. Verify no more "Cannot read properties of undefined" errors

### DirecTV Fix Testing:
1. Try sending a DirecTV command from the remote control
2. If 403 error occurs, follow the instructions in the error message
3. Enable External Device Access on the DirecTV receiver
4. Restart the receiver and test again
5. Verify commands work or show improved error messages

## Impact

✅ **Eliminates** "Cannot read properties of undefined" errors  
✅ **Prevents** database connection pool exhaustion  
✅ **Improves** application stability  
✅ **Provides** clear troubleshooting guidance for DirecTV issues  
✅ **Documents** solutions for future reference  

## Deployment Notes

After merging:
1. Pull latest changes on production server
2. Run `npm install` (if needed)
3. Run `npx prisma generate`
4. Run `npm run build`
5. Restart PM2: `pm2 restart sports-bar-tv`
6. Monitor logs for any issues

---

**⚠️ IMPORTANT:** Do NOT merge this PR until the user has verified the fixes work as expected.