### PR TITLE
Fix: Resolve Q&A generation Prisma schema mismatch

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -409,6 +409,7 @@ model QAEntry {
   answer      String   // Training answer
   category    String   @default("general") // Category: general, technical, troubleshooting, etc.
   tags        String?  // JSON array of tags
+  sourceFile  String?  // Source file path or identifier
   sourceType  String   @default("manual") // manual, generated, imported
   confidence  Float    @default(1.0) // Confidence score 0-1
   useCount    Int      @default(0) // Number of times this Q&A was used
@@ -420,6 +421,7 @@ model QAEntry {
   @@index([category])
   @@index([isActive])
   @@index([sourceType])
+  @@index([sourceFile])
 }
 
 // Training documents uploaded by users


### PR DESCRIPTION
## Problem
Q&A Training System generation was failing with Prisma errors:
- `Unknown argument 'sourceFile'. Did you mean 'sourceType'?`
- Invalid `prisma.qAEntry.findFirst()` invocation
- Generation status showing **failed** with 0 Q&As generated

## Root Cause
The code in multiple files (`qa-generator.ts`, `tvDocs/index.ts`) was trying to use a `sourceFile` field that didn't exist in the QAEntry Prisma model. The schema only had `sourceType`, causing a mismatch.

## Solution
Added `sourceFile` field to the QAEntry model in `prisma/schema.prisma`:
- Added as optional String field (`sourceFile String?`)
- Added index on sourceFile for query performance
- Positioned logically between tags and sourceType fields

## Changes
- ✅ Updated `prisma/schema.prisma` - Added sourceFile field to QAEntry model
- ✅ Generated new Prisma client with updated schema

## Testing Required
After merging, on the production server:
1. Pull latest changes
2. Run `npx prisma db push` to update the database schema
3. Run `npx prisma generate` to regenerate client
4. Restart the application with `pm2 restart sports-bar-tv`
5. Test Q&A generation from both Repository and Docs sources
6. Verify Q&As are created successfully with sourceFile populated

## Files Modified
- `prisma/schema.prisma` - Added sourceFile field and index to QAEntry model