### PR TITLE
Fix React error #31 and Atlas name normalization issues

### DIFF
--- a/src/app/api/atlas/query-hardware/route.ts
+++ b/src/app/api/atlas/query-hardware/route.ts
@@ -80,33 +80,78 @@ export async function POST(request: NextRequest) {
       }, { status: 500 })
     }
 
-    // Convert hardware config to API format
-    const inputs = hardwareConfig.sources.map(source => ({
-      id: `source_${source.index}`,
-      number: source.index + 1, // 1-based numbering for display
-      name: source.name,
-      type: 'atlas_configured',
-      connector: 'Hardware',
-      description: `Atlas configured source: ${source.name}`,
-      parameterName: source.parameterName,
-      isCustom: true,
-      queriedFromHardware: true
-    }))
+    // Helper function to extract string from Atlas name format
+    // Atlas can return names in various formats:
+    // - Plain string: "Input 1"
+    // - Object with str: {str: "Input 1"}
+    // - Object with param and str: {param: "InputName", str: "Input 1"}
+    // - Array: [{str: "Input 1"}]
+    const extractNameString = (nameField: any, defaultName: string): string => {
+      // Already a string
+      if (typeof nameField === 'string') {
+        return nameField
+      }
+      
+      // Object with str property
+      if (nameField && typeof nameField === 'object') {
+        // Handle {param: "...", str: "..."}
+        if (nameField.str) {
+          return String(nameField.str)
+        }
+        // Handle {val: "..."}
+        if (nameField.val !== undefined) {
+          return String(nameField.val)
+        }
+      }
+      
+      // Array format
+      if (Array.isArray(nameField) && nameField.length > 0) {
+        const first = nameField[0]
+        if (typeof first === 'string') {
+          return first
+        }
+        if (first && typeof first === 'object' && first.str) {
+          return String(first.str)
+        }
+      }
+      
+      // Fallback to default
+      return defaultName
+    }
 
-    const outputs = hardwareConfig.zones.map(zone => ({
-      id: `zone_${zone.index}`,
-      number: zone.index + 1, // 1-based numbering for display
-      name: zone.name,
-      type: 'zone',
-      connector: 'Hardware',
-      description: `Atlas configured zone: ${zone.name}`,
-      parameterName: zone.parameterName,
-      currentSource: zone.currentSource,
-      volume: zone.volume,
-      muted: zone.muted,
-      isCustom: true,
-      queriedFromHardware: true
-    }))
+    // Convert hardware config to API format with proper string extraction
+    const inputs = hardwareConfig.sources.map(source => {
+      const name = extractNameString(source.name, `Input ${source.index + 1}`)
+      return {
+        id: `source_${source.index}`,
+        number: source.index + 1, // 1-based numbering for display
+        name: name,
+        type: 'atlas_configured',
+        connector: 'Hardware',
+        description: `Atlas configured source: ${name}`,
+        parameterName: source.parameterName,
+        isCustom: true,
+        queriedFromHardware: true
+      }
+    })
+
+    const outputs = hardwareConfig.zones.map(zone => {
+      const name = extractNameString(zone.name, `Zone ${zone.index + 1}`)
+      return {
+        id: `zone_${zone.index}`,
+        number: zone.index + 1, // 1-based numbering for display
+        name: name,
+        type: 'zone',
+        connector: 'Hardware',
+        description: `Atlas configured zone: ${name}`,
+        parameterName: zone.parameterName,
+        currentSource: zone.currentSource,
+        volume: zone.volume,
+        muted: zone.muted,
+        isCustom: true,
+        queriedFromHardware: true
+      }
+    })
 
     // Save configuration to file
     const config = {

--- a/src/components/AtlasProgrammingInterface.tsx
+++ b/src/components/AtlasProgrammingInterface.tsx
@@ -179,11 +179,40 @@ export default function AtlasProgrammingInterface() {
         console.log('[Atlas Config] Received configuration:', config)
         
         // Helper function to extract string from Atlas name format
-        const extractName = (nameField: any, defaultName: string) => {
-          if (typeof nameField === 'string') return nameField
-          if (Array.isArray(nameField) && nameField.length > 0 && nameField[0].str) {
-            return nameField[0].str || defaultName
+        // This prevents React error #31 by ensuring we never try to render objects
+        const extractName = (nameField: any, defaultName: string): string => {
+          // Already a string - most common case
+          if (typeof nameField === 'string') {
+            return nameField
           }
+          
+          // Object with str property: {str: "Input 1"} or {param: "InputName", str: "Input 1"}
+          if (nameField && typeof nameField === 'object' && !Array.isArray(nameField)) {
+            if (nameField.str !== undefined) {
+              return String(nameField.str)
+            }
+            if (nameField.val !== undefined) {
+              return String(nameField.val)
+            }
+          }
+          
+          // Array format: [{str: "Input 1"}]
+          if (Array.isArray(nameField) && nameField.length > 0) {
+            const first = nameField[0]
+            if (typeof first === 'string') {
+              return first
+            }
+            if (first && typeof first === 'object') {
+              if (first.str !== undefined) {
+                return String(first.str)
+              }
+              if (first.val !== undefined) {
+                return String(first.val)
+              }
+            }
+          }
+          
+          // Fallback to default - ensures we always return a string
           return defaultName
         }
         


### PR DESCRIPTION
## Problem Summary

This PR fixes two critical issues that were preventing the Atlas Programming Interface from working correctly:

### 1. **React Error #31**: "Minified React error #31"
- **Root Cause**: The Atlas hardware returns data in format `{param: "InputName", str: "Input 1"}` but the application was trying to render these objects directly in React components
- **Error Message**: "Objects are not valid as a React child (found: object with keys {param, str})"
- **Impact**: Application crashes when displaying Atlas input/output names

### 2. **Query Hardware 500 Error**
- **Root Cause**: The `/api/atlas/query-hardware` endpoint was not properly extracting string values from Atlas response objects before saving to configuration files
- **Impact**: Query Hardware button fails with 500 Internal Server Error

## Solution

### Changes Made

#### 1. **API Route Fix** (`src/app/api/atlas/query-hardware/route.ts`)
- Added `extractNameString()` helper function that handles all Atlas data formats
- Converts Atlas response objects to plain strings before saving to configuration
- Ensures configuration files only contain string values, not objects

#### 2. **Component Fix** (`src/components/AtlasProgrammingInterface.tsx`)
- Enhanced `extractName()` helper function with comprehensive type checking
- Added defensive checks to prevent rendering objects in React
- Handles all possible Atlas response formats with proper fallbacks

### Supported Atlas Data Formats

Both helper functions now handle:
- ✅ Plain strings: `"Input 1"`
- ✅ Objects with str: `{str: "Input 1"}`
- ✅ Objects with param and str: `{param: "InputName", str: "Input 1"}`
- ✅ Objects with val: `{val: "Input 1"}`
- ✅ Arrays: `[{str: "Input 1"}]`

## Testing Recommendations

After merging this PR, please test:

1. **Query Hardware Button**
   - Click "Query Hardware" in Atlas Programming Interface
   - Verify no 500 errors occur
   - Verify input/output names display correctly as strings

2. **Configuration Display**
   - Check that all input names display as plain text (e.g., "Input 1", "Input 2")
   - Check that all zone names display as plain text (e.g., "Zone 1", "Zone 2")
   - Verify no React error #31 appears in console

3. **Configuration Saving**
   - Save configuration after querying hardware
   - Verify configuration file contains only string values
   - Reload page and verify names still display correctly

## Deployment Steps

After merging:
```bash
ssh -p 224 ubuntu@24.123.87.42
cd ~/Sports-Bar-TV-Controller
git pull origin main
npm run build
pm2 restart sports-bar-tv-controller
```

## Related Information

- **Atlas Unit**: 192.168.5.101:5321 (AtlasIED Atmosphere AZM8)
- **Server**: 24.123.87.42:3000
- **Issues Fixed**: React error #31, Query Hardware 500 error

## Notes

- This fix is backward compatible with existing saved configurations
- The extractName functions provide sensible defaults if data is malformed
- All type conversions use `String()` to ensure proper string coercion