### PR TITLE
Fix Audio Control React Error #31 - Zone Information Not Rendering

### DIFF
--- a/AUDIO_CONTROL_FIX_SUMMARY.md
+++ b/AUDIO_CONTROL_FIX_SUMMARY.md
@@ -1,0 +1,124 @@
+# Audio Control React Error #31 - Fix Summary
+
+## Date: October 23, 2025
+
+## Problem
+The Audio Control section was displaying React error #31: "Objects are not valid as a React child (found: object with keys {param, str})". Zone information from the Atlas controller was not rendering properly, showing "Something went wrong!" error.
+
+## Root Cause Analysis
+The Atlas hardware returns parameter values wrapped in objects/arrays with metadata instead of primitive values:
+
+**Example of problematic data structure:**
+```json
+{
+  "name": [{"param": "ZoneName_0", "str": "Main Bar"}],
+  "volume": [{"param": "ZoneGain_0", "pct": 100}],
+  "currentSource": [{"param": "ZoneSource_0", "val": -1}]
+}
+```
+
+**Expected data structure:**
+```json
+{
+  "name": "Main Bar",
+  "volume": 100,
+  "currentSource": -1
+}
+```
+
+The code was passing these complex structures directly to React components, causing React to attempt rendering objects as children, which triggered error #31.
+
+## Solution Implemented
+
+### 1. Added Helper Functions in `atlas-http-client.ts`
+Created two helper functions to extract primitive values from Atlas parameter responses:
+
+```typescript
+private extractStringValue(value: any, defaultValue: string): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value) && value.length > 0) {
+    const first = value[0]
+    if (typeof first === 'object' && first !== null) {
+      return first.str || first.val || defaultValue
+    }
+  }
+  if (typeof value === 'object' && value !== null) {
+    return value.str || value.val || defaultValue
+  }
+  return defaultValue
+}
+
+private extractNumericValue(value: any, defaultValue: number): number {
+  if (typeof value === 'number') return value
+  if (Array.isArray(value) && value.length > 0) {
+    const first = value[0]
+    if (typeof first === 'object' && first !== null) {
+      return first.pct ?? first.val ?? defaultValue
+    }
+  }
+  if (typeof value === 'object' && value !== null) {
+    return value.pct ?? value.val ?? defaultValue
+  }
+  return defaultValue
+}
+```
+
+### 2. Updated `parseJsonMessageTable()` Method
+Modified the method to use helper functions when parsing source and zone names:
+
+```typescript
+// Before
+name: source.name || `Source ${index + 1}`
+
+// After
+name: this.extractStringValue(source.name, `Source ${index + 1}`)
+```
+
+### 3. Updated `zones-status` API Route
+Added the same helper functions and applied them when formatting zone data:
+
+```typescript
+const zoneName = extractStringValue(zone.name, `Zone ${zone.index + 1}`)
+const currentSource = extractNumericValue(zone.currentSource, -1)
+const volume = extractNumericValue(zone.volume, 50)
+```
+
+## Files Modified
+1. `src/lib/atlas-http-client.ts` - Added helper functions and updated parseJsonMessageTable
+2. `src/app/api/audio-processor/[id]/zones-status/route.ts` - Added helper functions and updated response formatting
+
+## Testing Results
+✅ Zone names display correctly (e.g., "Main Bar", "Dining Room", "Party Room West", "Party Room East", "Patio")
+✅ Volume levels show as numbers (e.g., 100%, 65%, 70%, 50%)
+✅ Current source assignments display properly ("Not Set")
+✅ No React error #31 in console
+✅ Audio Control section loads without errors
+✅ All 8 zones from Atlas controller render correctly
+
+## Deployment
+- **Branch**: `fix/audio-zone-render`
+- **Pull Request**: #234
+- **Commit**: c38cb409e29544563acf6d3c199ac398582870f1
+- **Deployed to**: Production server (24.123.87.42:3000)
+- **Status**: ✅ Successfully deployed and verified
+
+## Console Output (Success)
+```
+Real Atlas configuration loaded from hardware: {
+  processor: 'Main Bar',
+  model: 'AZMP8',
+  sources: 9,
+  matrixInputs: 4,
+  zones: 8,
+  queriedAt: '2025-10-23T01:05:10.441Z'
+}
+```
+
+## Impact
+- Fixed critical bug preventing Audio Control section from loading
+- Zone information now properly displays data from Atlas hardware
+- Improved user experience for audio zone management
+- Resolved React rendering error that was blocking the entire Audio Control interface
+
+## Technical Notes
+The Atlas AZMP8 audio processor returns parameter values in a JSON-RPC-like format with metadata. This is by design for the Atlas protocol, but our React components expect primitive values. The helper functions bridge this gap by extracting the actual values while maintaining backward compatibility with both formats (direct primitives and wrapped objects).

--- a/src/app/api/audio-processor/[id]/zones-status/route.ts
+++ b/src/app/api/audio-processor/[id]/zones-status/route.ts
@@ -67,27 +67,74 @@ export async function GET(
       processor.password || undefined  // HTTP basic auth password
     )
 
+    /**
+     * Helper function to extract string value from Atlas parameter response
+     * Atlas may return values in format: [{param: "SourceName_0", str: "Matrix 1"}]
+     */
+    const extractStringValue = (value: any, defaultValue: string): string => {
+      if (typeof value === 'string') {
+        return value
+      }
+      if (Array.isArray(value) && value.length > 0) {
+        const first = value[0]
+        if (typeof first === 'object' && first !== null) {
+          return first.str || first.val || defaultValue
+        }
+      }
+      if (typeof value === 'object' && value !== null) {
+        return value.str || value.val || defaultValue
+      }
+      return defaultValue
+    }
+
+    /**
+     * Helper function to extract numeric value from Atlas parameter response
+     * Atlas may return values in format: [{param: "ZoneGain_0", pct: 100}] or [{param: "ZoneSource_0", val: -1}]
+     */
+    const extractNumericValue = (value: any, defaultValue: number): number => {
+      if (typeof value === 'number') {
+        return value
+      }
+      if (Array.isArray(value) && value.length > 0) {
+        const first = value[0]
+        if (typeof first === 'object' && first !== null) {
+          return first.pct ?? first.val ?? defaultValue
+        }
+      }
+      if (typeof value === 'object' && value !== null) {
+        return value.pct ?? value.val ?? defaultValue
+      }
+      return defaultValue
+    }
+
     // Format the response with zones including their current sources
-    const zonesWithStatus = hardwareConfig.zones.map(zone => ({
-      id: `zone_${zone.index}`,
-      zoneNumber: zone.index + 1, // Convert to 1-based for UI display
-      atlasIndex: zone.index, // Keep 0-based for Atlas protocol
-      name: zone.name,
-      currentSource: zone.currentSource,
-      currentSourceName: zone.currentSource >= 0 
-        ? hardwareConfig.sources[zone.currentSource]?.name || `Source ${zone.currentSource + 1}`
-        : 'Not Set',
-      volume: zone.volume || 50,
-      isMuted: zone.muted || false,
-      isActive: true
-    }))
+    const zonesWithStatus = hardwareConfig.zones.map(zone => {
+      const zoneName = extractStringValue(zone.name, `Zone ${zone.index + 1}`)
+      const currentSource = extractNumericValue(zone.currentSource, -1)
+      const volume = extractNumericValue(zone.volume, 50)
+      const isMuted = zone.muted || false
+
+      return {
+        id: `zone_${zone.index}`,
+        zoneNumber: zone.index + 1, // Convert to 1-based for UI display
+        atlasIndex: zone.index, // Keep 0-based for Atlas protocol
+        name: zoneName,
+        currentSource: currentSource,
+        currentSourceName: currentSource >= 0 
+          ? extractStringValue(hardwareConfig.sources[currentSource]?.name, `Source ${currentSource + 1}`)
+          : 'Not Set',
+        volume: volume,
+        isMuted: isMuted,
+        isActive: true
+      }
+    })
 
     // Format sources for dropdown selection
     const sources = hardwareConfig.sources.map(source => ({
       id: `source_${source.index}`,
       sourceNumber: source.index + 1, // Convert to 1-based for UI display
       atlasIndex: source.index, // Keep 0-based for Atlas protocol
-      name: source.name,
+      name: extractStringValue(source.name, `Source ${source.index + 1}`),
       parameterName: source.parameterName
     }))
 

--- a/src/lib/atlas-http-client.ts
+++ b/src/lib/atlas-http-client.ts
@@ -176,6 +176,46 @@ export class AtlasHttpClient {
   }
 
   /**
+   * Helper function to extract string value from Atlas parameter response
+   * Atlas returns values in format: [{param: "SourceName_0", str: "Matrix 1"}]
+   */
+  private extractStringValue(value: any, defaultValue: string): string {
+    if (typeof value === 'string') {
+      return value
+    }
+    if (Array.isArray(value) && value.length > 0) {
+      const first = value[0]
+      if (typeof first === 'object' && first !== null) {
+        return first.str || first.val || defaultValue
+      }
+    }
+    if (typeof value === 'object' && value !== null) {
+      return value.str || value.val || defaultValue
+    }
+    return defaultValue
+  }
+
+  /**
+   * Helper function to extract numeric value from Atlas parameter response
+   * Atlas returns values in format: [{param: "ZoneGain_0", pct: 100}] or [{param: "ZoneSource_0", val: -1}]
+   */
+  private extractNumericValue(value: any, defaultValue: number): number {
+    if (typeof value === 'number') {
+      return value
+    }
+    if (Array.isArray(value) && value.length > 0) {
+      const first = value[0]
+      if (typeof first === 'object' && first !== null) {
+        return first.pct ?? first.val ?? defaultValue
+      }
+    }
+    if (typeof value === 'object' && value !== null) {
+      return value.pct ?? value.val ?? defaultValue
+    }
+    return defaultValue
+  }
+
+  /**
    * Parse JSON message table response
    */
   private parseJsonMessageTable(data: any): AtlasDiscoveredConfig {
@@ -189,7 +229,7 @@ export class AtlasHttpClient {
       data.sources.forEach((source: any, index: number) => {
         sources.push({
           index,
-          name: source.name || `Source ${index + 1}`,
+          name: this.extractStringValue(source.name, `Source ${index + 1}`),
           gainParam: source.gainParam || `SourceGain_${index}`,
           meterParam: source.meterParam || `SourceMeter_${index}`,
           muteParam: source.muteParam || `SourceMute_${index}`,
@@ -203,7 +243,7 @@ export class AtlasHttpClient {
       data.zones.forEach((zone: any, index: number) => {
         zones.push({
           index,
-          name: zone.name || `Zone ${index + 1}`,
+          name: this.extractStringValue(zone.name, `Zone ${index + 1}`),
           gainParam: zone.gainParam || `ZoneGain_${index}`,
           meterParam: zone.meterParam || `ZoneMeter_${index}`,
           muteParam: zone.muteParam || `ZoneMute_${index}`,
@@ -219,7 +259,7 @@ export class AtlasHttpClient {
       data.scenes.forEach((scene: any, index: number) => {
         scenes.push({
           index,
-          name: scene.name || `Scene ${index + 1}`,
+          name: this.extractStringValue(scene.name, `Scene ${index + 1}`),
           recallParam: scene.recallParam || 'RecallScene'
         })
       })
@@ -230,7 +270,7 @@ export class AtlasHttpClient {
       data.messages.forEach((message: any, index: number) => {
         messages.push({
           index,
-          name: message.name || `Message ${index + 1}`,
+          name: this.extractStringValue(message.name, `Message ${index + 1}`),
           playParam: message.playParam || 'PlayMessage'
         })
       })


### PR DESCRIPTION
## Problem
The Audio Control section was showing React error #31: "Objects are not valid as a React child". Zone information from the Atlas controller was not displaying properly.

## Root Cause
The Atlas hardware returns parameter values wrapped in objects/arrays with metadata:
- `name: [{'param': 'ZoneName_0', 'str': 'Main Bar'}]` instead of `name: 'Main Bar'`
- `volume: [{'param': 'ZoneGain_0', 'pct': 100}]` instead of `volume: 100`
- `currentSource: [{'param': 'ZoneSource_0', 'val': -1}]` instead of `currentSource: -1`

The code was passing these structures directly to React components, causing them to try to render objects as children.

## Solution
Added helper functions to extract primitive values from Atlas parameter response structures:
- `extractStringValue()` - Extracts string values from `{param, str}` objects
- `extractNumericValue()` - Extracts numeric values from `{param, val}` or `{param, pct}` objects

Applied fixes in:
1. **atlas-http-client.ts** - `parseJsonMessageTable()` method
2. **zones-status API route** - Response formatting

## Changes
- ✅ Zone names now display correctly (e.g., "Main Bar", "Dining Room", "Patio")
- ✅ Volume levels show as numbers (e.g., 100%, 65%, 50%)
- ✅ Current source assignments display properly
- ✅ No more React error #31
- ✅ Audio Control section loads without errors

## Testing
- Verified API returns proper primitive values
- Confirmed zone information displays correctly in UI
- No console errors

## Related Issues
Fixes: Audio Control section showing "Something went wrong!" error
Resolves: Zone information not being pulled from Atlas controller