### PR TITLE
Integrate Atlas Audio Enhancement Components

### DIFF
--- a/src/app/remote/page.tsx
+++ b/src/app/remote/page.tsx
@@ -30,7 +30,7 @@ import SportsGuide from '@/components/SportsGuide'
 import TVGuide from '@/components/TVGuide'
 import EnhancedChannelGuideBartenderRemote from '@/components/EnhancedChannelGuideBartenderRemote'
 import BartenderMusicControl from '@/components/BartenderMusicControl'
-import AudioZoneControl from '@/components/AudioZoneControl'
+import BartenderRemoteAudioPanel from '@/components/BartenderRemoteAudioPanel'
 
 interface MatrixInput {
   id: string
@@ -894,7 +894,7 @@ export default function BartenderRemotePage() {
 
         {activeTab === 'audio' && (
           <div className="max-w-7xl mx-auto">
-            <AudioZoneControl bartenderMode={true} />
+            <BartenderRemoteAudioPanel />
           </div>
         )}
 

--- a/src/components/AudioControlTabs.tsx
+++ b/src/components/AudioControlTabs.tsx
@@ -5,6 +5,7 @@ import { Sliders, Volume2, Disc, Settings, Brain } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import AtlasProgrammingInterface from '@/components/AtlasProgrammingInterface'
 import AtlasAIMonitor from '@/components/AtlasAIMonitor'
+import AtlasOutputMeters from '@/components/AtlasOutputMeters'
 import AudioZoneControl from '@/components/AudioZoneControl'
 import SoundtrackControl from '@/components/SoundtrackControl'
 import SoundtrackConfiguration from '@/components/SoundtrackConfiguration'
@@ -105,6 +106,15 @@ export default function AudioControlTabs() {
               
               <TabsContent value="configuration" className="mt-6">
                 <AtlasProgrammingInterface />
+                
+                {/* Atlas Output Meters */}
+                <div className="mt-6">
+                  <AtlasOutputMeters 
+                    processorId={activeProcessor?.id || "atlas-001"}
+                    autoRefresh={true}
+                    refreshInterval={1000}
+                  />
+                </div>
               </TabsContent>
               
               <TabsContent value="ai-monitor" className="mt-6">


### PR DESCRIPTION
## Summary
This PR completes the integration of the new Atlas audio enhancement components that were merged in PR #239.

## Changes Made

### 1. Remote Control Page (`src/app/remote/page.tsx`)
- **Replaced** `AudioZoneControl` with `BartenderRemoteAudioPanel`
- The new component provides comprehensive audio controls with tabs for:
  - Zones
  - Groups
  - Input Meters
  - Output Meters

### 2. Audio Control Center (`src/components/AudioControlTabs.tsx`)
- **Added** `AtlasOutputMeters` component to the Atlas System tab
- Positioned after `AtlasProgrammingInterface` in the Configuration section
- Configured with:
  - Auto-refresh enabled
  - 1-second refresh interval for real-time meter updates
  - Processor ID from active processor state

## Features Now Available

### Bartender Remote - Audio Tab
- ✅ Zone volume controls
- ✅ Group management
- ✅ Input level meters (real-time)
- ✅ Output level meters (real-time)

### Audio Control Center - Atlas System
- ✅ Atlas programming interface
- ✅ Output meters with group visualization
- ✅ AI monitoring

## Testing Checklist
- [ ] Navigate to Remote Control → Audio tab
- [ ] Verify all four tabs are visible (Zones, Groups, Input Meters, Output Meters)
- [ ] Navigate to Audio Control Center → Atlas System
- [ ] Verify output meters display below programming interface
- [ ] Confirm real-time meter updates are working

## Deployment Notes
After merging, deploy to remote server:
```bash
cd ~/Sports-Bar-TV-Controller
git pull origin main
npm ci --omit=dev
npm run build
pm2 restart sports-bar-tv-controller
```

## Related
- Closes integration work started after PR #239
- Components: AtlasGroupsControl, AtlasInputMeters, AtlasOutputMeters, BartenderRemoteAudioPanel