### PR TITLE
Fix: SQL syntax error in prisma-adapter composite key handling

### DIFF
--- a/src/db/prisma-adapter.ts
+++ b/src/db/prisma-adapter.ts
@@ -72,7 +72,26 @@ if (!where) return undefined
 const conditions: any[] = []
 
 Object.entries(where).forEach(([field, value]) => {
+// Check if this is a composite key (e.g., processorId_zoneNumber)
+// Composite keys contain underscore and the field doesn't exist in table
+if (field.includes('_') && !table[field]) {
+// This is a composite key, extract individual fields
+if (typeof value === 'object' && value !== null) {
+Object.entries(value).forEach(([subField, subValue]) => {
+const column = table[subField]
+if (column) {
+conditions.push(eq(column, subValue))
+}
+})
+}
+return
+}
+
 const column = table[field]
+if (!column) {
+console.warn(`[prisma-adapter] Column ${field} not found in table`)
+return
+}
 
 if (value === null) {
 conditions.push(eq(column, null))


### PR DESCRIPTION
## Problem
The application was experiencing SQL syntax errors (`SqliteError: near "=": syntax error`) when calling `prisma.audioZone.upsert()` with composite keys in the `/api/atlas/query-hardware` route.

## Root Cause
The `convertWhere` function in `src/db/prisma-adapter.ts` was not handling Prisma's composite key syntax properly. When code used:
```typescript
prisma.audioZone.upsert({
  where: {
    processorId_zoneNumber: {
      processorId: 'xxx',
      zoneNumber: 1
    }
  },
  ...
})
```

The adapter tried to access `table['processorId_zoneNumber']` which doesn't exist as a column, causing malformed SQL to be generated.

## Solution
Enhanced the `convertWhere` function to:
1. Detect composite keys (fields with underscores that don't exist in the table schema)
2. Extract individual field values from the composite key object
3. Create proper Drizzle ORM `eq()` conditions for each field
4. Combine them using `and()` for the final where clause
5. Added warning logging for missing columns to aid future debugging

## Testing
- ✅ Composite key detection logic
- ✅ Individual field extraction
- ✅ Proper SQL generation with `and()` conditions
- ✅ Backward compatibility with existing single-field where clauses

## Impact
- Fixes the SQL error in Atlas hardware query endpoint
- Resolves 500 errors when querying Atlas processor zones
- Maintains backward compatibility with all existing Prisma adapter usage
- No breaking changes to the API

## Related Issues
- Resolves SQL syntax errors in production logs
- Fixes Atlas zone upsert operations
- Part of the Prisma to Drizzle migration cleanup