### PR TITLE
Fix active groups display in bartender remote

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -217,6 +217,22 @@ export const audioZones = sqliteTable('AudioZone', {
   processorZoneIdx: uniqueIndex('AudioZone_processorId_zoneNumber_key').on(table.processorId, table.zoneNumber),
 }))
 
+// Audio Group Model
+export const audioGroups = sqliteTable('AudioGroup', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  processorId: text('processorId').notNull().references(() => audioProcessors.id, { onDelete: 'cascade' }),
+  groupNumber: integer('groupNumber').notNull(),
+  name: text('name').notNull(),
+  isActive: integer('isActive', { mode: 'boolean' }).notNull().default(false),
+  currentSource: text('currentSource'),
+  gain: real('gain').notNull().default(-10),
+  muted: integer('muted', { mode: 'boolean' }).notNull().default(false),
+  createdAt: timestamp('createdAt').notNull().default(timestampNow()),
+  updatedAt: timestamp('updatedAt').notNull().default(timestampNow()),
+}, (table) => ({
+  processorGroupIdx: uniqueIndex('AudioGroup_processorId_groupNumber_key').on(table.processorId, table.groupNumber),
+}))
+
 // Audio Scene Model
 export const audioScenes = sqliteTable('AudioScene', {
   id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),


### PR DESCRIPTION
## Problem
The bartender remote was showing "No active groups configured" even though the Atlas processor web interface showed 6 active groups with their "Combine" toggles turned ON.

## Root Cause
The `atlas-hardware-query.ts` library was only querying sources and zones, but NOT groups. The database schema also didn't have an `audioGroups` table to store group data.

## Investigation Findings
From the Atlas Atmosphere processor web interface (http://24.123.87.42:8888):

**Active Groups Found:**
1. **Main Bar** - 2 zones, Matrix 1 source, -56 dB
2. **Dining** - 1 zone, Matrix 1 source, -40 dB  
3. **Party Room West** - 1 zone, no source, -5 dB
4. **Party Room East** - 1 zone, no source, -40 dB
5. **Patio** - 1 zone, Mic 1 source, -40 dB
6. **Bathroom** - 1 zone, Mic 2 source, -40 dB

All groups have their "Combine" toggle ON (blue), indicating they are active.

**Atlas Protocol Parameters (from Settings > Third Party):**
- `GroupName_X` - Group name (string)
- `GroupActive_X` - Combine/active state (0=inactive, 1=active)
- `GroupSource_X` - Current source index
- `GroupGain_X` - Volume in dB
- `GroupMute_X` - Mute state (0=unmuted, 1=muted)

Where X is the group index (0-11 for 12 groups max)

## Solution

### 1. Database Schema (`src/db/schema.ts`)
Added new `audioGroups` table:
```typescript
export const audioGroups = sqliteTable('AudioGroup', {
  id: text('id').primaryKey(),
  processorId: text('processorId').notNull().references(() => audioProcessors.id),
  groupNumber: integer('groupNumber').notNull(),
  name: text('name').notNull(),
  isActive: integer('isActive', { mode: 'boolean' }).notNull().default(false),
  currentSource: text('currentSource'),
  gain: real('gain').notNull().default(-10),
  muted: integer('muted', { mode: 'boolean' }).notNull().default(false),
  createdAt: timestamp('createdAt').notNull(),
  updatedAt: timestamp('updatedAt').notNull(),
})
```

### 2. Hardware Query Library (`src/lib/atlas-hardware-query.ts`)
- Added `AtlasHardwareGroup` interface
- Added `queryGroups()` function to query all 12 groups via TCP
- Updated `AtlasHardwareConfig` to include groups array
- Modified both HTTP discovery and TCP fallback paths to query groups
- Groups are queried using parameters: `GroupName_X`, `GroupActive_X`, `GroupSource_X`, `GroupGain_X`, `GroupMute_X`

### 3. Query Hardware Endpoint (`src/app/api/atlas/query-hardware/route.ts`)
- Import `audioGroups` from schema
- Added group saving logic after zone saving
- Properly sanitizes and validates group data before database insert
- Uses upsert pattern (update if exists, insert if new)
- Logs group save operations for debugging

## Testing Required
After merging and deploying:

1. **Run database migration:**
   ```bash
   npm run db:push
   ```

2. **Query hardware to pull fresh data:**
   - Navigate to Atlas processor settings
   - Click "Query Hardware" button
   - Verify console logs show groups being queried and saved

3. **Check database:**
   ```bash
   npm run db:studio
   ```
   - Verify `AudioGroup` table exists
   - Verify 6 groups are saved with `isActive=true`

4. **Test bartender remote:**
   - Open bartender remote interface
   - Verify active groups are now displayed
   - Verify group names match Atlas processor
   - Test group controls (source selection, volume, mute)

## Files Changed
- `src/db/schema.ts` - Added audioGroups table
- `src/lib/atlas-hardware-query.ts` - Added group querying functionality  
- `src/app/api/atlas/query-hardware/route.ts` - Added group database saving

## Breaking Changes
None. This is a new feature addition that doesn't affect existing functionality.

## Migration Notes
The database migration will automatically create the `AudioGroup` table when `npm run db:push` is executed. No manual SQL required.