### PR TITLE
Fix group query errors and improve error logging

### DIFF
--- a/src/lib/atlas-hardware-query.ts
+++ b/src/lib/atlas-hardware-query.ts
@@ -651,6 +651,7 @@ async function queryGroups(
   const groups: AtlasHardwareGroup[] = []
   
   console.log(`[Atlas Query] Querying ${maxGroups} groups...`)
+  console.log(`[Atlas Query] NOTE: Only GroupName_X and GroupActive_X parameters are supported by Atlas processor`)
   
   for (let i = 0; i < maxGroups; i++) {
     try {
@@ -672,32 +673,12 @@ async function queryGroups(
         isActive = active === 1
       }
 
-      // Get current source
-      const sourceResponse = await client.getParameter(`GroupSource_${i}`, 'val')
-      let currentSource = -1
-      
-      if (sourceResponse.success && sourceResponse.data) {
-        const source = extractValueFromResponse(sourceResponse.data, 'val')
-        if (source !== null && source !== undefined) currentSource = source
-      }
-
-      // Get gain (in dB)
-      const gainResponse = await client.getParameter(`GroupGain_${i}`, 'val')
-      let gain = -10
-      
-      if (gainResponse.success && gainResponse.data) {
-        const gainVal = extractValueFromResponse(gainResponse.data, 'val')
-        if (gainVal !== null && gainVal !== undefined) gain = gainVal
-      }
-
-      // Get mute state
-      const muteResponse = await client.getParameter(`GroupMute_${i}`, 'val')
-      let muted = false
-      
-      if (muteResponse.success && muteResponse.data) {
-        const muteVal = extractValueFromResponse(muteResponse.data, 'val')
-        muted = muteVal === 1
-      }
+      // NOTE: GroupSource_X, GroupGain_X, and GroupMute_X are NOT supported by Atlas processor
+      // Groups inherit these properties from their member zones
+      // Using default/placeholder values for now
+      const currentSource = -1  // Not available from Atlas
+      const gain = 0             // Not available from Atlas
+      const muted = false        // Not available from Atlas
 
       groups.push({
         index: i,
@@ -709,7 +690,7 @@ async function queryGroups(
         muted
       })
 
-      console.log(`[Atlas Query] Group ${i}: ${groupName} (Active: ${isActive}, Source: ${currentSource}, Gain: ${gain} dB, Muted: ${muted})`)
+      console.log(`[Atlas Query] Group ${i}: ${groupName} (Active: ${isActive})`)
       
       await delay(100) // Small delay between queries
     } catch (error) {

--- a/src/lib/atlas-logger.ts
+++ b/src/lib/atlas-logger.ts
@@ -176,7 +176,7 @@ export const atlasLogger = {
    */
   error(category: string, message: string, error: any) {
     writeLog('ERROR', category.toUpperCase(), message, {
-      error: error instanceof Error ? error.message : String(error),
+      error: error instanceof Error ? error.message : (typeof error === 'object' ? JSON.stringify(error) : String(error)),
       stack: error instanceof Error ? error.stack : undefined
     })
   },


### PR DESCRIPTION
## Problem
After deploying PR #252 (groups fix), the application was getting many "[object Object]" errors when trying to get parameters from the Atlas processor:

```
[ERROR] [GET] Error getting parameter | { "error": "[object Object]" }
[ERROR] [RESPONSE] Atlas command error | { "error": "[object Object]" }
```

These errors were caused by:
1. Poor error serialization in the logger (converting objects to string resulted in "[object Object]")
2. Attempting to query unsupported Atlas parameters (GroupSource_X, GroupGain_X, GroupMute_X)

## Root Cause
The Atlas processor only supports these group parameters:
- `GroupName_X` - Group name (read-only)
- `GroupActive_X` - Group activation state (combine zones)

The code was incorrectly trying to query:
- `GroupSource_X` ❌ (not supported)
- `GroupGain_X` ❌ (not supported)  
- `GroupMute_X` ❌ (not supported)

Groups inherit source, gain, and mute properties from their member zones - these are not available as separate group parameters.

## Solution

### 1. Fixed Error Logging
Updated `atlas-logger.ts` to properly serialize error objects:
```typescript
error: error instanceof Error ? error.message : (typeof error === 'object' ? JSON.stringify(error) : String(error))
```

Now actual error messages will be visible instead of "[object Object]".

### 2. Removed Unsupported Parameter Queries
Updated `queryGroups()` in `atlas-hardware-query.ts` to:
- Only query `GroupName_X` and `GroupActive_X` (supported parameters)
- Use placeholder values for source/gain/mute (not available from Atlas)
- Add explanatory comments about Atlas processor limitations

## Testing Required
1. Deploy to remote server (24.123.87.42)
2. Check PM2 logs - should see actual error messages if any issues occur
3. Verify groups show in bartender remote at http://24.123.87.42:3001/remote
4. Confirm no more "[object Object]" errors in logs

## Related
- Fixes issues introduced in PR #252
- Addresses bartender remote groups not showing