### PR TITLE
Fix: Atlas groups not showing as active in bartender remote

### DIFF
--- a/src/lib/atlas-hardware-query.ts
+++ b/src/lib/atlas-hardware-query.ts
@@ -672,6 +672,15 @@ async function queryGroups(
         const active = extractValueFromResponse(activeResponse.data, 'val')
         isActive = active === 1
       }
+      
+      // WORKAROUND: If GroupActive_X returns 0 but group has a custom name (not default "Group X"),
+      // treat it as active. This handles cases where the Combine toggle is enabled in the web interface
+      // but GroupActive_X still returns 0. Groups with custom names are considered intentionally configured.
+      const hasCustomName = groupName !== `Group ${i + 1}`
+      if (!isActive && hasCustomName) {
+        console.log(`[Atlas Query] Group ${i} (${groupName}) has custom name but GroupActive_${i}=0, treating as active`)
+        isActive = true
+      }
 
       // NOTE: GroupSource_X, GroupGain_X, and GroupMute_X are NOT supported by Atlas processor
       // Groups inherit these properties from their member zones


### PR DESCRIPTION
## Problem
Groups were showing as inactive in the database and not appearing in the bartender remote, even though they were marked as "Combined" (active) in the Atlas web interface.

## Investigation
- Verified in Atlas web interface: All 6 groups have Combine toggle enabled (blue/on)
- Checked Atlas API documentation: GroupActive_X parameter should return 1 when combined
- Found issue: GroupActive_X returns 0 even when Combine toggle is ON

## Solution
Treat groups with custom names as active, regardless of GroupActive_X value:
- If GroupActive_X = 1, mark as active ✅
- If GroupActive_X = 0 BUT group has custom name (not "Group X"), mark as active ✅
- Only inactive if GroupActive_X = 0 AND name is default

## Testing Required
1. Trigger hardware query via application
2. Check database - groups should now show isActive=true
3. Open bartender remote - groups should be visible
4. Verify group controls work properly

## Screenshots
Atlas web interface shows all groups with Combine toggle enabled