### PR TITLE
Fix: Add missing AudioGroup table migration - Groups not showing issue

### DIFF
--- a/apply-audio-groups-migration.sh
+++ b/apply-audio-groups-migration.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Migration script to add AudioGroup table to production database
+# This fixes the issue where groups are not showing in bartender remote
+
+set -e
+
+echo "=== Audio Groups Migration Script ==="
+echo "This script will add the AudioGroup table to the database"
+echo ""
+
+# Find the database file
+DB_PATH=""
+if [ -f "./prisma/data/sports_bar.db" ]; then
+    DB_PATH="./prisma/data/sports_bar.db"
+elif [ -f "./data/sports_bar.db" ]; then
+    DB_PATH="./data/sports_bar.db"
+else
+    echo "Error: Could not find sports_bar.db"
+    exit 1
+fi
+
+echo "Found database at: $DB_PATH"
+echo ""
+
+# Backup the database
+BACKUP_PATH="${DB_PATH}.backup-$(date +%Y%m%d-%H%M%S)"
+echo "Creating backup at: $BACKUP_PATH"
+cp "$DB_PATH" "$BACKUP_PATH"
+echo "Backup created successfully"
+echo ""
+
+# Check if table already exists
+TABLE_EXISTS=$(sqlite3 "$DB_PATH" "SELECT name FROM sqlite_master WHERE type='table' AND name='AudioGroup';" 2>/dev/null || echo "")
+
+if [ -n "$TABLE_EXISTS" ]; then
+    echo "AudioGroup table already exists. Skipping migration."
+    exit 0
+fi
+
+# Apply migration
+echo "Applying migration..."
+sqlite3 "$DB_PATH" << 'EOF'
+-- CreateTable: AudioGroup
+CREATE TABLE "AudioGroup" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "processorId" TEXT NOT NULL,
+  "groupNumber" INTEGER NOT NULL,
+  "name" TEXT NOT NULL,
+  "isActive" INTEGER DEFAULT 0 NOT NULL,
+  "currentSource" TEXT,
+  "gain" REAL DEFAULT -10 NOT NULL,
+  "muted" INTEGER DEFAULT 0 NOT NULL,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL,
+  FOREIGN KEY ("processorId") REFERENCES "AudioProcessor"("id") ON DELETE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AudioGroup_processorId_groupNumber_key" ON "AudioGroup"("processorId", "groupNumber");
+EOF
+
+# Verify migration
+TABLE_EXISTS=$(sqlite3 "$DB_PATH" "SELECT name FROM sqlite_master WHERE type='table' AND name='AudioGroup';")
+
+if [ -n "$TABLE_EXISTS" ]; then
+    echo ""
+    echo "✓ Migration applied successfully!"
+    echo "✓ AudioGroup table created"
+    echo ""
+    echo "Next steps:"
+    echo "1. Restart the application: pm2 restart all"
+    echo "2. Go to Atlas Programming Interface and click 'Query Hardware'"
+    echo "3. Groups should now appear in Bartender Remote"
+else
+    echo ""
+    echo "✗ Migration failed!"
+    echo "Restoring backup..."
+    cp "$BACKUP_PATH" "$DB_PATH"
+    echo "Database restored from backup"
+    exit 1
+fi

--- a/create_audio_group_migration.sql
+++ b/create_audio_group_migration.sql
@@ -1,0 +1,17 @@
+-- Create AudioGroup table
+CREATE TABLE IF NOT EXISTS "AudioGroup" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "processorId" TEXT NOT NULL,
+  "groupNumber" INTEGER NOT NULL,
+  "name" TEXT NOT NULL,
+  "isActive" INTEGER DEFAULT 0 NOT NULL,
+  "currentSource" TEXT,
+  "gain" REAL DEFAULT -10 NOT NULL,
+  "muted" INTEGER DEFAULT 0 NOT NULL,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL,
+  FOREIGN KEY ("processorId") REFERENCES "AudioProcessor"("id") ON DELETE CASCADE
+);
+
+-- Create unique index for processorId and groupNumber
+CREATE UNIQUE INDEX IF NOT EXISTS "AudioGroup_processorId_groupNumber_key" ON "AudioGroup"("processorId", "groupNumber");

--- a/prisma/migrations/20251024_add_audio_groups/migration.sql
+++ b/prisma/migrations/20251024_add_audio_groups/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable: AudioGroup
+-- This migration adds support for Atlas audio groups (combined zone groups)
+-- Groups allow controlling multiple zones together as a single unit
+
+CREATE TABLE IF NOT EXISTS "AudioGroup" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "processorId" TEXT NOT NULL,
+  "groupNumber" INTEGER NOT NULL,
+  "name" TEXT NOT NULL,
+  "isActive" INTEGER DEFAULT 0 NOT NULL,
+  "currentSource" TEXT,
+  "gain" REAL DEFAULT -10 NOT NULL,
+  "muted" INTEGER DEFAULT 0 NOT NULL,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL,
+  FOREIGN KEY ("processorId") REFERENCES "AudioProcessor"("id") ON DELETE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "AudioGroup_processorId_groupNumber_key" ON "AudioGroup"("processorId", "groupNumber");


### PR DESCRIPTION
## Problem
Groups were not showing in Bartender Remote even after:
- Deleting and recreating groups in Atlas web interface
- Rebooting Atlas processor
- Turning third party control back on
- Requerying hardware multiple times

## Root Cause Analysis
After investigating the git history and database, I discovered that:

1. **PR #252** added the `audioGroups` table definition to `src/db/schema.ts`
2. **However, no database migration was created or applied** to actually create the table in the production database
3. The `AudioGroup` table never existed in the database
4. When hardware query ran, it tried to save groups but **failed silently** due to the missing table
5. This caused groups to always show as inactive with default names

## The Fix
This PR adds the missing database migration:

### Changes Made:
1. **Created migration file**: `prisma/migrations/20251024_add_audio_groups/migration.sql`
   - Adds AudioGroup table with proper schema
   - Includes unique index on (processorId, groupNumber)
   - Proper foreign key constraint to AudioProcessor

2. **Created deployment script**: `apply-audio-groups-migration.sh`
   - Automated migration script for production
   - Includes database backup before migration
   - Verifies migration success
   - Safe rollback on failure

### Table Schema:
```sql
CREATE TABLE "AudioGroup" (
  "id" TEXT PRIMARY KEY NOT NULL,
  "processorId" TEXT NOT NULL,
  "groupNumber" INTEGER NOT NULL,
  "name" TEXT NOT NULL,
  "isActive" INTEGER DEFAULT 0 NOT NULL,
  "currentSource" TEXT,
  "gain" REAL DEFAULT -10 NOT NULL,
  "muted" INTEGER DEFAULT 0 NOT NULL,
  "createdAt" TEXT NOT NULL,
  "updatedAt" TEXT NOT NULL,
  FOREIGN KEY ("processorId") REFERENCES "AudioProcessor"("id") ON DELETE CASCADE
);
```

## Deployment Steps
1. Merge this PR
2. SSH into production server
3. Pull latest code: `cd ~/Sports-Bar-TV-Controller && git pull origin main`
4. Run migration: `./apply-audio-groups-migration.sh`
5. Restart application: `pm2 restart all`
6. Go to Atlas Programming Interface and click "Query Hardware"
7. Verify groups now appear in Bartender Remote with correct names and active status

## Testing
- ✅ Migration tested locally on development database
- ✅ Table created successfully with proper schema
- ✅ Unique index created correctly
- ✅ Foreign key constraint working

## Impact
- **Fixes**: Groups not showing in Bartender Remote
- **Enables**: Proper group management and control
- **No Breaking Changes**: Only adds missing table, doesn't modify existing functionality

## Related Issues
- Resolves the issue where groups configured in Atlas don't appear in the application
- Fixes silent failures in hardware query when saving group data