### PR TITLE
Fix: Global Cache test endpoint SQLite binding error

### DIFF
--- a/src/app/api/globalcache/devices/[id]/test/route.ts
+++ b/src/app/api/globalcache/devices/[id]/test/route.ts
@@ -30,7 +30,7 @@ export async function POST(
     // Update device status
     await db.update(globalCacheDevices).set({
         status: result.online ? 'online' : 'offline',
-        lastSeen: result.online ? new Date() : device.lastSeen
+        lastSeen: result.online ? new Date().toISOString() : device.lastSeen
       }).where(eq(globalCacheDevices.id, params.id)).returning().get()
 
     console.log(`Connection test result: ${result.online ? 'ONLINE' : 'OFFLINE'}`)


### PR DESCRIPTION
## Description
Fixes the SQLite binding error in the Global Cache device test endpoint that was causing 500 Internal Server Errors.

## Problem
- Error: `TypeError: SQLite3 can only bind numbers, strings, bigints, buffers, and null`
- Occurred when testing Global Cache device connections
- Endpoint: `/api/globalcache/devices/[id]/test`

## Solution
- Converted `new Date()` to `new Date().toISOString()` when updating the `lastSeen` field
- Ensures proper timestamp storage as TEXT in SQLite (compatible with Drizzle ORM schema)

## Changes
- Modified: `src/app/api/globalcache/devices/[id]/test/route.ts`
- Changed line 33: `lastSeen: result.online ? new Date() : device.lastSeen` 
- To: `lastSeen: result.online ? new Date().toISOString() : device.lastSeen`

## Testing
- ✅ Local build successful
- Ready for deployment and remote testing